### PR TITLE
Murisi/masp

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -215,7 +215,7 @@ zxerr_t crypto_hashSigSection(const signature_section_t *signature_section, cons
             break;
         }
         case Address:
-            CHECK_CX_OK(cx_sha256_update(&sha256, signature_section->address.ptr, signature_section->address.len));
+            CHECK_CX_OK(cx_sha256_update(&sha256, signature_section->addressBytes.ptr, signature_section->addressBytes.len));
             break;
 
         default:

--- a/app/src/mem.c
+++ b/app/src/mem.c
@@ -1,0 +1,65 @@
+/**
+ * Dynamic allocator that uses a fixed-length buffer that is hopefully big enough
+ *
+ * The two functions alloc & dealloc use the buffer as a simple stack.
+ * Especially useful when an unpredictable amount of data will be received and have to be stored
+ * during the transaction but discarded right after.
+ */
+
+//#ifdef HAVE_DYN_MEM_ALLOC
+
+#include <stdint.h>
+#include "mem.h"
+
+#define SIZE_MEM_BUFFER 8192
+
+static uint8_t mem_buffer[SIZE_MEM_BUFFER];
+static size_t mem_idx;
+
+/**
+ * Initializes the memory buffer index
+ */
+void mem_init(void) {
+    mem_idx = 0;
+}
+
+/**
+ * Resets the memory buffer index
+ */
+void mem_reset(void) {
+    mem_init();
+}
+
+/**
+ * Allocates (push) a chunk of the memory buffer of a given size.
+ *
+ * Checks to see if there are enough space left in the memory buffer, returns
+ * the current location in the memory buffer and moves the index accordingly.
+ *
+ * @param[in] size Requested allocation size in bytes
+ * @return Allocated memory pointer; \ref NULL if not enough space left.
+ */
+void *mem_alloc(size_t size) {
+    if ((mem_idx + size) > SIZE_MEM_BUFFER)  // Buffer exceeded
+    {
+        return NULL;
+    }
+    mem_idx += size;
+    return &mem_buffer[mem_idx - size];
+}
+
+/**
+ * De-allocates (pop) a chunk of memory buffer by a given size.
+ *
+ * @param[in] size Requested deallocation size in bytes
+ */
+void mem_dealloc(size_t size) {
+    if (size > mem_idx)  // More than is already allocated
+    {
+        mem_idx = 0;
+    } else {
+        mem_idx -= size;
+    }
+}
+
+//#endif  // HAVE_DYN_MEM_ALLOC

--- a/app/src/mem.h
+++ b/app/src/mem.h
@@ -1,0 +1,15 @@
+#ifndef MEM_H_
+#define MEM_H_
+
+//#ifdef HAVE_DYN_MEM_ALLOC
+
+#include <stdlib.h>
+
+void mem_init(void);
+void mem_reset(void);
+void *mem_alloc(size_t size);
+void mem_dealloc(size_t size);
+
+//#endif  // HAVE_DYN_MEM_ALLOC
+
+#endif  // MEM_H_

--- a/app/src/parser_impl_common.h
+++ b/app/src/parser_impl_common.h
@@ -100,9 +100,10 @@ parser_error_t readFieldSizeU16(parser_context_t *ctx, uint16_t *size);
 parser_error_t checkTag(parser_context_t *ctx, uint8_t expectedTag);
 parser_error_t readPubkey(parser_context_t *ctx, bytes_t *pubkey);
 
-parser_error_t readToken(const bytes_t *token, const char **symbol);
+parser_error_t readToken(const AddressAlt *token, const char **symbol);
 parser_error_t readAddress(bytes_t pubkeyHash, char *address, uint16_t addressLen);
-parser_error_t encodeAddress(AddressAlt *addr, char *address, uint16_t addressLen);
+parser_error_t readAddressAlt(parser_context_t *ctx, AddressAlt *obj);
+parser_error_t encodeAddress(const AddressAlt *addr, char *address, uint16_t addressLen);
 parser_error_t readVote(bytes_t *vote, yay_vote_type_e type, char *strVote, uint16_t strVoteLen);
 
 parser_error_t readHeader(parser_context_t *ctx, parser_tx_t *v);

--- a/app/src/parser_impl_common.h
+++ b/app/src/parser_impl_common.h
@@ -102,6 +102,7 @@ parser_error_t readPubkey(parser_context_t *ctx, bytes_t *pubkey);
 
 parser_error_t readToken(const bytes_t *token, const char **symbol);
 parser_error_t readAddress(bytes_t pubkeyHash, char *address, uint16_t addressLen);
+parser_error_t encodeAddress(AddressAlt *addr, char *address, uint16_t addressLen);
 parser_error_t readVote(bytes_t *vote, yay_vote_type_e type, char *strVote, uint16_t strVoteLen);
 
 parser_error_t readHeader(parser_context_t *ctx, parser_tx_t *v);

--- a/app/src/parser_impl_txn.c
+++ b/app/src/parser_impl_txn.c
@@ -374,6 +374,587 @@ parser_error_t readValueSumAssetType_i128(parser_context_t *ctx, ValueSumAssetTy
 
 
 
+
+typedef struct {
+  uint8_t f0;
+  uint8_t f1[32];
+} u8_u8_32;
+
+typedef struct {
+  ValueSumAssetType_i128 assets;
+  uint8_t generator[32];
+} AllowedConversion;
+
+typedef struct {
+  uint8_t f0[32];
+} ChainCode;
+
+typedef struct {
+  uint32_t f0;
+} ChildIndex;
+
+typedef struct {
+  uint8_t auth_pathLen;
+  u8_u8_32 *auth_path;
+  uint64_t position;
+} MerklePathu8_32;
+
+typedef struct {
+  AllowedConversion allowed;
+  uint64_t value;
+  MerklePathu8_32 merkle_path;
+} ConvertDescriptionInfo;
+
+typedef struct {
+  uint8_t f0[11];
+} Diversifier;
+
+typedef struct {
+  uint8_t f0[32];
+} DiversifierKey;
+
+typedef struct {
+  uint8_t f0[32];
+} NullifierDerivingKey;
+
+typedef struct {
+  uint8_t ak[32];
+  NullifierDerivingKey nk;
+} ViewingKey;
+
+typedef struct {
+  uint8_t f0[32];
+} OutgoingViewingKey;
+
+typedef struct {
+  ViewingKey vk;
+  OutgoingViewingKey ovk;
+} FullViewingKey;
+
+typedef struct {
+  uint8_t f0[4];
+} FvkTag;
+
+typedef struct {
+  uint8_t depth;
+  FvkTag parent_fvk_tag;
+  ChildIndex child_index;
+  ChainCode chain_code;
+  FullViewingKey fvk;
+  DiversifierKey dk;
+} ExtendedFullViewingKey;
+
+typedef struct {
+  uint8_t f0[512];
+} MemoBytes;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint8_t BeforeZip212[32];
+  uint8_t AfterZip212[32];
+  };
+} Rseed;
+
+typedef struct {
+  AssetType asset_type;
+  uint64_t value;
+  uint8_t g_d[32];
+  uint8_t pk_d[32];
+  Rseed rseed;
+} Note;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  OutgoingViewingKey Some;
+  };
+} OptionOutgoingViewingKey;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint8_t Some[32];
+  };
+} Optionu8_32;
+
+typedef struct {
+  Diversifier diversifier;
+  uint8_t pk_d[32];
+} PaymentAddress;
+
+typedef struct {
+  ExtendedFullViewingKey extsk;
+  Diversifier diversifier;
+  Note note;
+  uint8_t alpha[32];
+  MerklePathu8_32 merkle_path;
+} SpendDescriptionInfoExtendedFullViewingKey;
+
+typedef struct {
+  OptionOutgoingViewingKey ovk;
+  PaymentAddress to;
+  Note note;
+  MemoBytes memo;
+} SaplingOutputInfo;
+
+typedef struct {
+  Optionu8_32 spend_anchor;
+  BlockHeight target_height;
+  ValueSumAssetType_i128 value_balance;
+  Optionu8_32 convert_anchor;
+  uint32_t spendsLen;
+  SpendDescriptionInfoExtendedFullViewingKey *spends;
+  uint32_t convertsLen;
+  ConvertDescriptionInfo *converts;
+  uint32_t outputsLen;
+  SaplingOutputInfo *outputs;
+} SaplingBuilder_ExtendedFullViewingKey;
+
+typedef struct {
+  TxOut coin;
+} TransparentInputInfo;
+
+typedef struct {
+  uint32_t inputsLen;
+  TransparentInputInfo *inputs;
+  uint32_t voutLen;
+  TxOut *vout;
+} TransparentBuilder;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+  };
+} ValueSumAssetType_i128_CompactSize;
+
+typedef struct {
+  BlockHeight target_height;
+  BlockHeight expiry_height;
+  TransparentBuilder transparent_builder;
+  SaplingBuilder_ExtendedFullViewingKey sapling_builder;
+} Builder__ExtendedFullViewingKey;
+
+typedef struct {
+  uint8_t f0[32];
+} Hash;
+
+typedef struct {
+  uint32_t spend_indicesLen;
+  uint64_t *spend_indices;
+  uint32_t convert_indicesLen;
+  uint64_t *convert_indices;
+  uint32_t output_indicesLen;
+  uint64_t *output_indices;
+} SaplingMetadata;
+
+typedef struct {
+  uint8_t bytes[ADDRESS_LEN_BYTES];
+} AddressAlt;
+
+typedef struct {
+  uint64_t f0;
+} Epoch;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  Epoch Some;
+  };
+} OptionEpoch;
+
+typedef struct {
+  uint8_t f0;
+} Denomination;
+
+typedef struct {
+  uint8_t tag;
+} MaspDigitPos;
+
+typedef struct {
+  AddressAlt token;
+  Denomination denom;
+  MaspDigitPos position;
+  OptionEpoch epoch;
+} AssetData;
+
+typedef struct {
+  Hash target;
+  uint32_t asset_typesLen;
+  AssetData *asset_types;
+  SaplingMetadata metadata;
+  Builder__ExtendedFullViewingKey builder;
+} MaspBuilder;
+
+parser_error_t readu8_u8_32(parser_context_t *ctx, u8_u8_32 *obj);
+parser_error_t readAllowedConversion(parser_context_t *ctx, AllowedConversion *obj);
+parser_error_t readBuilder__ExtendedFullViewingKey(parser_context_t *ctx, Builder__ExtendedFullViewingKey *obj);
+parser_error_t readChainCode(parser_context_t *ctx, ChainCode *obj);
+parser_error_t readChildIndex(parser_context_t *ctx, ChildIndex *obj);
+parser_error_t readConvertDescriptionInfo(parser_context_t *ctx, ConvertDescriptionInfo *obj);
+parser_error_t readDiversifier(parser_context_t *ctx, Diversifier *obj);
+parser_error_t readDiversifierKey(parser_context_t *ctx, DiversifierKey *obj);
+parser_error_t readExtendedFullViewingKey(parser_context_t *ctx, ExtendedFullViewingKey *obj);
+parser_error_t readFullViewingKey(parser_context_t *ctx, FullViewingKey *obj);
+parser_error_t readFvkTag(parser_context_t *ctx, FvkTag *obj);
+parser_error_t readMemoBytes(parser_context_t *ctx, MemoBytes *obj);
+parser_error_t readMerklePathu8_32(parser_context_t *ctx, MerklePathu8_32 *obj);
+parser_error_t readNote(parser_context_t *ctx, Note *obj);
+parser_error_t readNullifierDerivingKey(parser_context_t *ctx, NullifierDerivingKey *obj);
+parser_error_t readOptionOutgoingViewingKey(parser_context_t *ctx, OptionOutgoingViewingKey *obj);
+parser_error_t readOptionu8_32(parser_context_t *ctx, Optionu8_32 *obj);
+parser_error_t readOutgoingViewingKey(parser_context_t *ctx, OutgoingViewingKey *obj);
+parser_error_t readPaymentAddress(parser_context_t *ctx, PaymentAddress *obj);
+parser_error_t readRseed(parser_context_t *ctx, Rseed *obj);
+parser_error_t readSaplingBuilder_ExtendedFullViewingKey(parser_context_t *ctx, SaplingBuilder_ExtendedFullViewingKey *obj);
+parser_error_t readSaplingOutputInfo(parser_context_t *ctx, SaplingOutputInfo *obj);
+parser_error_t readSpendDescriptionInfoExtendedFullViewingKey(parser_context_t *ctx, SpendDescriptionInfoExtendedFullViewingKey *obj);
+parser_error_t readTransparentBuilder(parser_context_t *ctx, TransparentBuilder *obj);
+parser_error_t readTransparentInputInfo(parser_context_t *ctx, TransparentInputInfo *obj);
+parser_error_t readValueSumAssetType_i128_CompactSize(parser_context_t *ctx, ValueSumAssetType_i128_CompactSize *obj);
+parser_error_t readViewingKey(parser_context_t *ctx, ViewingKey *obj);
+parser_error_t readMaspBuilder(parser_context_t *ctx, MaspBuilder *obj);
+parser_error_t readHash(parser_context_t *ctx, Hash *obj);
+parser_error_t readAssetData(parser_context_t *ctx, AssetData *obj);
+parser_error_t readSaplingMetadata(parser_context_t *ctx, SaplingMetadata *obj);
+parser_error_t readOptionEpoch(parser_context_t *ctx, OptionEpoch *obj);
+parser_error_t readEpoch(parser_context_t *ctx, Epoch *obj);
+parser_error_t readDenomination(parser_context_t *ctx, Denomination *obj);
+parser_error_t readMaspDigitPos(parser_context_t *ctx, MaspDigitPos *obj);
+
+parser_error_t readu8_u8_32(parser_context_t *ctx, u8_u8_32 *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->f0))
+  CHECK_ERROR(readBytesAlt(ctx, obj->f1, 32))
+  return parser_ok;
+}
+
+parser_error_t readAllowedConversion(parser_context_t *ctx, AllowedConversion *obj) {
+  CHECK_ERROR(readValueSumAssetType_i128(ctx, &obj->assets))
+  CHECK_ERROR(readBytesAlt(ctx, obj->generator, 32))
+  return parser_ok;
+}
+
+parser_error_t readBuilder__ExtendedFullViewingKey(parser_context_t *ctx, Builder__ExtendedFullViewingKey *obj) {
+  CHECK_ERROR(readBlockHeight(ctx, &obj->target_height))
+  CHECK_ERROR(readBlockHeight(ctx, &obj->expiry_height))
+  CHECK_ERROR(readTransparentBuilder(ctx, &obj->transparent_builder))
+  CHECK_ERROR(readSaplingBuilder_ExtendedFullViewingKey(ctx, &obj->sapling_builder))
+  return parser_ok;
+}
+
+parser_error_t readChainCode(parser_context_t *ctx, ChainCode *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 32))
+  return parser_ok;
+}
+
+parser_error_t readChildIndex(parser_context_t *ctx, ChildIndex *obj) {
+  CHECK_ERROR(readUint32(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readConvertDescriptionInfo(parser_context_t *ctx, ConvertDescriptionInfo *obj) {
+  CHECK_ERROR(readAllowedConversion(ctx, &obj->allowed))
+  CHECK_ERROR(readUint64(ctx, &obj->value))
+  CHECK_ERROR(readMerklePathu8_32(ctx, &obj->merkle_path))
+  return parser_ok;
+}
+
+parser_error_t readDiversifier(parser_context_t *ctx, Diversifier *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 11))
+  return parser_ok;
+}
+
+parser_error_t readDiversifierKey(parser_context_t *ctx, DiversifierKey *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 32))
+  return parser_ok;
+}
+
+parser_error_t readExtendedFullViewingKey(parser_context_t *ctx, ExtendedFullViewingKey *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->depth))
+  CHECK_ERROR(readFvkTag(ctx, &obj->parent_fvk_tag))
+  CHECK_ERROR(readChildIndex(ctx, &obj->child_index))
+  CHECK_ERROR(readChainCode(ctx, &obj->chain_code))
+  CHECK_ERROR(readFullViewingKey(ctx, &obj->fvk))
+  CHECK_ERROR(readDiversifierKey(ctx, &obj->dk))
+  return parser_ok;
+}
+
+parser_error_t readFullViewingKey(parser_context_t *ctx, FullViewingKey *obj) {
+  CHECK_ERROR(readViewingKey(ctx, &obj->vk))
+  CHECK_ERROR(readOutgoingViewingKey(ctx, &obj->ovk))
+  return parser_ok;
+}
+
+parser_error_t readFvkTag(parser_context_t *ctx, FvkTag *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 4))
+  return parser_ok;
+}
+
+parser_error_t readMemoBytes(parser_context_t *ctx, MemoBytes *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 512))
+  return parser_ok;
+}
+
+parser_error_t readMerklePathu8_32(parser_context_t *ctx, MerklePathu8_32 *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->auth_pathLen))
+  if((obj->auth_path = mem_alloc(obj->auth_pathLen * sizeof(u8_u8_32))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->auth_pathLen; i++) {
+    CHECK_ERROR(readu8_u8_32(ctx, &obj->auth_path[i]))
+  }
+  CHECK_ERROR(readUint64(ctx, &obj->position))
+  return parser_ok;
+}
+
+parser_error_t readNote(parser_context_t *ctx, Note *obj) {
+  CHECK_ERROR(readAssetType(ctx, &obj->asset_type))
+  CHECK_ERROR(readUint64(ctx, &obj->value))
+  CHECK_ERROR(readBytesAlt(ctx, obj->g_d, 32))
+  CHECK_ERROR(readBytesAlt(ctx, obj->pk_d, 32))
+  CHECK_ERROR(readRseed(ctx, &obj->rseed))
+  return parser_ok;
+}
+
+parser_error_t readNullifierDerivingKey(parser_context_t *ctx, NullifierDerivingKey *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 32))
+  return parser_ok;
+}
+
+parser_error_t readOptionOutgoingViewingKey(parser_context_t *ctx, OptionOutgoingViewingKey *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 0:
+  break;
+  case 1:
+  CHECK_ERROR(readOutgoingViewingKey(ctx, &obj->Some))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readOptionu8_32(parser_context_t *ctx, Optionu8_32 *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 0:
+  break;
+  case 1:
+  CHECK_ERROR(readBytesAlt(ctx, obj->Some, 32))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readOutgoingViewingKey(parser_context_t *ctx, OutgoingViewingKey *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 32))
+  return parser_ok;
+}
+
+parser_error_t readPaymentAddress(parser_context_t *ctx, PaymentAddress *obj) {
+  CHECK_ERROR(readDiversifier(ctx, &obj->diversifier))
+  CHECK_ERROR(readBytesAlt(ctx, obj->pk_d, 32))
+  return parser_ok;
+}
+
+parser_error_t readRseed(parser_context_t *ctx, Rseed *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 1:
+  CHECK_ERROR(readBytesAlt(ctx, obj->BeforeZip212, 32))
+  break;
+  case 2:
+  CHECK_ERROR(readBytesAlt(ctx, obj->AfterZip212, 32))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readSaplingBuilder_ExtendedFullViewingKey(parser_context_t *ctx, SaplingBuilder_ExtendedFullViewingKey *obj) {
+  CHECK_ERROR(readOptionu8_32(ctx, &obj->spend_anchor))
+  CHECK_ERROR(readBlockHeight(ctx, &obj->target_height))
+  CHECK_ERROR(readValueSumAssetType_i128(ctx, &obj->value_balance))
+  CHECK_ERROR(readOptionu8_32(ctx, &obj->convert_anchor))
+  CHECK_ERROR(readUint32(ctx, &obj->spendsLen))
+  if((obj->spends = mem_alloc(obj->spendsLen * sizeof(SpendDescriptionInfoExtendedFullViewingKey))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->spendsLen; i++) {
+    CHECK_ERROR(readSpendDescriptionInfoExtendedFullViewingKey(ctx, &obj->spends[i]))
+  }
+  CHECK_ERROR(readUint32(ctx, &obj->convertsLen))
+  if((obj->converts = mem_alloc(obj->convertsLen * sizeof(ConvertDescriptionInfo))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->convertsLen; i++) {
+    CHECK_ERROR(readConvertDescriptionInfo(ctx, &obj->converts[i]))
+  }
+  CHECK_ERROR(readUint32(ctx, &obj->outputsLen))
+  if((obj->outputs = mem_alloc(obj->outputsLen * sizeof(SaplingOutputInfo))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->outputsLen; i++) {
+    CHECK_ERROR(readSaplingOutputInfo(ctx, &obj->outputs[i]))
+  }
+  return parser_ok;
+}
+
+parser_error_t readSaplingOutputInfo(parser_context_t *ctx, SaplingOutputInfo *obj) {
+  CHECK_ERROR(readOptionOutgoingViewingKey(ctx, &obj->ovk))
+  CHECK_ERROR(readPaymentAddress(ctx, &obj->to))
+  CHECK_ERROR(readNote(ctx, &obj->note))
+  CHECK_ERROR(readMemoBytes(ctx, &obj->memo))
+  return parser_ok;
+}
+
+parser_error_t readSpendDescriptionInfoExtendedFullViewingKey(parser_context_t *ctx, SpendDescriptionInfoExtendedFullViewingKey *obj) {
+  CHECK_ERROR(readExtendedFullViewingKey(ctx, &obj->extsk))
+  CHECK_ERROR(readDiversifier(ctx, &obj->diversifier))
+  CHECK_ERROR(readNote(ctx, &obj->note))
+  CHECK_ERROR(readBytesAlt(ctx, obj->alpha, 32))
+  CHECK_ERROR(readMerklePathu8_32(ctx, &obj->merkle_path))
+  return parser_ok;
+}
+
+parser_error_t readTransparentBuilder(parser_context_t *ctx, TransparentBuilder *obj) {
+  CHECK_ERROR(readUint32(ctx, &obj->inputsLen))
+  if((obj->inputs = mem_alloc(obj->inputsLen * sizeof(TransparentInputInfo))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->inputsLen; i++) {
+    CHECK_ERROR(readTransparentInputInfo(ctx, &obj->inputs[i]))
+  }
+  CHECK_ERROR(readUint32(ctx, &obj->voutLen))
+  if((obj->vout = mem_alloc(obj->voutLen * sizeof(TxOut))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->voutLen; i++) {
+    CHECK_ERROR(readTxOut(ctx, &obj->vout[i]))
+  }
+  return parser_ok;
+}
+
+parser_error_t readTransparentInputInfo(parser_context_t *ctx, TransparentInputInfo *obj) {
+  CHECK_ERROR(readTxOut(ctx, &obj->coin))
+  return parser_ok;
+}
+
+parser_error_t readValueSumAssetType_i128_CompactSize(parser_context_t *ctx, ValueSumAssetType_i128_CompactSize *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 253:
+  CHECK_ERROR(readUint16(ctx, &obj->u16))
+  break;
+  case 254:
+  CHECK_ERROR(readUint32(ctx, &obj->u32))
+  break;
+  case 255:
+  CHECK_ERROR(readUint64(ctx, &obj->u64))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readViewingKey(parser_context_t *ctx, ViewingKey *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->ak, 32))
+  CHECK_ERROR(readNullifierDerivingKey(ctx, &obj->nk))
+  return parser_ok;
+}
+
+parser_error_t readHash(parser_context_t *ctx, Hash *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 32))
+  return parser_ok;
+}
+
+parser_error_t readSaplingMetadata(parser_context_t *ctx, SaplingMetadata *obj) {
+  CHECK_ERROR(readUint32(ctx, &obj->spend_indicesLen))
+  if((obj->spend_indices = mem_alloc(obj->spend_indicesLen * sizeof(uint64_t))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->spend_indicesLen; i++) {
+    CHECK_ERROR(readUint64(ctx, &obj->spend_indices[i]))
+  }
+  CHECK_ERROR(readUint32(ctx, &obj->convert_indicesLen))
+  if((obj->convert_indices = mem_alloc(obj->convert_indicesLen * sizeof(uint64_t))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->convert_indicesLen; i++) {
+    CHECK_ERROR(readUint64(ctx, &obj->convert_indices[i]))
+  }
+  CHECK_ERROR(readUint32(ctx, &obj->output_indicesLen))
+  if((obj->output_indices = mem_alloc(obj->output_indicesLen * sizeof(uint64_t))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->output_indicesLen; i++) {
+    CHECK_ERROR(readUint64(ctx, &obj->output_indices[i]))
+  }
+  return parser_ok;
+}
+
+parser_error_t readAddressAlt(parser_context_t *ctx, AddressAlt *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->bytes, ADDRESS_LEN_BYTES))
+  return parser_ok;
+}
+
+parser_error_t readAssetData(parser_context_t *ctx, AssetData *obj) {
+  CHECK_ERROR(readAddressAlt(ctx, &obj->token))
+  CHECK_ERROR(readDenomination(ctx, &obj->denom))
+  CHECK_ERROR(readMaspDigitPos(ctx, &obj->position))
+  CHECK_ERROR(readOptionEpoch(ctx, &obj->epoch))
+  return parser_ok;
+}
+
+parser_error_t readMaspBuilder(parser_context_t *ctx, MaspBuilder *obj) {
+  CHECK_ERROR(readHash(ctx, &obj->target))
+  CHECK_ERROR(readUint32(ctx, &obj->asset_typesLen))
+  if((obj->asset_types = mem_alloc(obj->asset_typesLen * sizeof(AssetData))) == NULL) {
+    return parser_unexpected_error;
+  }
+  for(uint32_t i = 0; i < obj->asset_typesLen; i++) {
+    CHECK_ERROR(readAssetData(ctx, &obj->asset_types[i]))
+      }
+  CHECK_ERROR(readSaplingMetadata(ctx, &obj->metadata))
+  CHECK_ERROR(readBuilder__ExtendedFullViewingKey(ctx, &obj->builder))
+  return parser_ok;
+}
+
+parser_error_t readEpoch(parser_context_t *ctx, Epoch *obj) {
+  CHECK_ERROR(readUint64(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readOptionEpoch(parser_context_t *ctx, OptionEpoch *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 0:
+  break;
+  case 1:
+  CHECK_ERROR(readEpoch(ctx, &obj->Some))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readDenomination(parser_context_t *ctx, Denomination *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readMaspDigitPos(parser_context_t *ctx, MaspDigitPos *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  return parser_ok;
+}
+
+
+
+
+
+
+
+
+
 parser_error_t readToken(const bytes_t *token, const char **symbol) {
     if (token == NULL || symbol == NULL) {
         return parser_unexpected_value;
@@ -1537,11 +2118,17 @@ static parser_error_t readMaspTx(parser_context_t *ctx, masp_tx_section_t *maspT
     return parser_ok;
 }
 
-static parser_error_t readMaspBuilder(parser_context_t *ctx, section_t *maspBuilder) {
+static parser_error_t readMaspBuilderSection(parser_context_t *ctx, section_t *maspBuilder) {
     if (ctx == NULL) {
         return parser_unexpected_error;
     }
-    (void) maspBuilder;
+    uint8_t discriminant;
+    CHECK_ERROR(readByte(ctx, &discriminant))
+    if (discriminant != DISCRIMINANT_MASP_BUILDER) {
+        return parser_unexpected_value;
+    }
+    MaspBuilder mb;
+    CHECK_ERROR(readMaspBuilder(ctx, &mb))
     return parser_ok;
 }
 
@@ -1606,7 +2193,7 @@ parser_error_t readSections(parser_context_t *ctx, parser_tx_t *v) {
                 break;
 
             case DISCRIMINANT_MASP_BUILDER:
-                CHECK_ERROR(readMaspBuilder(ctx, NULL))
+                CHECK_ERROR(readMaspBuilderSection(ctx, NULL))
                 break;
 #if(0)
             case DISCRIMINANT_CIPHERTEXT:

--- a/app/src/parser_impl_txn.c
+++ b/app/src/parser_impl_txn.c
@@ -56,6 +56,87 @@ static const tokens_t nam_tokens[] = {
 #define PREFIX_ESTABLISHED 1
 #define PREFIX_INTERNAL 2
 
+parser_error_t readAssetType_i128(parser_context_t *ctx, AssetType_i128 *obj);
+parser_error_t readAssetType(parser_context_t *ctx, AssetType *obj);
+parser_error_t readAuthorized(parser_context_t *ctx, Authorized *obj);
+parser_error_t readBlockHeight(parser_context_t *ctx, BlockHeight *obj);
+parser_error_t readBranchId(parser_context_t *ctx, BranchId *obj);
+parser_error_t readConvertDescriptionV5(parser_context_t *ctx, ConvertDescriptionV5 *obj);
+parser_error_t readEphemeralKeyBytes(parser_context_t *ctx, EphemeralKeyBytes *obj);
+parser_error_t readNullifier(parser_context_t *ctx, Nullifier *obj);
+parser_error_t readOutputDescriptionV5(parser_context_t *ctx, OutputDescriptionV5 *obj);
+parser_error_t readPublicKey(parser_context_t *ctx, PublicKey *obj);
+parser_error_t readSignature(parser_context_t *ctx, Signature *obj);
+parser_error_t readSpendDescriptionV5(parser_context_t *ctx, SpendDescriptionV5 *obj);
+parser_error_t readTransaction(parser_context_t *ctx, Transaction *obj);
+parser_error_t readCompactSize(parser_context_t *ctx, CompactSize *obj);
+parser_error_t readTransaction_authorization(parser_context_t *ctx, Transaction_authorization *obj, uint64_t sd_v5s_count, uint64_t cd_v5s_count, uint64_t od_v5s_count);
+parser_error_t readTransaction_convert_anchor(parser_context_t *ctx, Transaction_convert_anchor *obj, uint64_t cd_v5s_count);
+parser_error_t readTransaction_spend_anchor(parser_context_t *ctx, Transaction_spend_anchor *obj, uint64_t sd_v5s_count);
+parser_error_t readTransaction_value_balance(parser_context_t *ctx, Transaction_value_balance *obj, uint64_t sd_v5s_count, uint64_t cd_v5s_count, uint64_t od_v5s_count);
+parser_error_t readTransparentAddress(parser_context_t *ctx, TransparentAddress *obj);
+parser_error_t readTxInAuthorized(parser_context_t *ctx, TxInAuthorized *obj);
+parser_error_t readTxOut(parser_context_t *ctx, TxOut *obj);
+parser_error_t readTxVersion(parser_context_t *ctx, TxVersion *obj);
+parser_error_t readValueSumAssetType_i128(parser_context_t *ctx, ValueSumAssetType_i128 *obj);
+parser_error_t readu8_u8_32(parser_context_t *ctx, u8_u8_32 *obj);
+parser_error_t readAllowedConversion(parser_context_t *ctx, AllowedConversion *obj);
+parser_error_t readBuilder__ExtendedFullViewingKey(parser_context_t *ctx, Builder__ExtendedFullViewingKey *obj);
+parser_error_t readChainCode(parser_context_t *ctx, ChainCode *obj);
+parser_error_t readChildIndex(parser_context_t *ctx, ChildIndex *obj);
+parser_error_t readConvertDescriptionInfo(parser_context_t *ctx, ConvertDescriptionInfo *obj);
+parser_error_t readDiversifier(parser_context_t *ctx, Diversifier *obj);
+parser_error_t readDiversifierKey(parser_context_t *ctx, DiversifierKey *obj);
+parser_error_t readExtendedFullViewingKey(parser_context_t *ctx, ExtendedFullViewingKey *obj);
+parser_error_t readFullViewingKey(parser_context_t *ctx, FullViewingKey *obj);
+parser_error_t readFvkTag(parser_context_t *ctx, FvkTag *obj);
+parser_error_t readMemoBytes(parser_context_t *ctx, MemoBytes *obj);
+parser_error_t readMerklePathu8_32(parser_context_t *ctx, MerklePathu8_32 *obj);
+parser_error_t readNote(parser_context_t *ctx, Note *obj);
+parser_error_t readNullifierDerivingKey(parser_context_t *ctx, NullifierDerivingKey *obj);
+parser_error_t readOptionOutgoingViewingKey(parser_context_t *ctx, OptionOutgoingViewingKey *obj);
+parser_error_t readOptionu8_32(parser_context_t *ctx, Optionu8_32 *obj);
+parser_error_t readOutgoingViewingKey(parser_context_t *ctx, OutgoingViewingKey *obj);
+parser_error_t readPaymentAddress(parser_context_t *ctx, PaymentAddress *obj);
+parser_error_t readRseed(parser_context_t *ctx, Rseed *obj);
+parser_error_t readSaplingBuilder_ExtendedFullViewingKey(parser_context_t *ctx, SaplingBuilder_ExtendedFullViewingKey *obj);
+parser_error_t readSaplingOutputInfo(parser_context_t *ctx, SaplingOutputInfo *obj);
+parser_error_t readSpendDescriptionInfoExtendedFullViewingKey(parser_context_t *ctx, SpendDescriptionInfoExtendedFullViewingKey *obj);
+parser_error_t readTransparentBuilder(parser_context_t *ctx, TransparentBuilder *obj);
+parser_error_t readTransparentInputInfo(parser_context_t *ctx, TransparentInputInfo *obj);
+parser_error_t readValueSumAssetType_i128_CompactSize(parser_context_t *ctx, ValueSumAssetType_i128_CompactSize *obj);
+parser_error_t readViewingKey(parser_context_t *ctx, ViewingKey *obj);
+parser_error_t readMaspBuilder(parser_context_t *ctx, MaspBuilder *obj);
+parser_error_t readHash(parser_context_t *ctx, Hash *obj);
+parser_error_t readAssetData(parser_context_t *ctx, AssetData *obj);
+parser_error_t readSaplingMetadata(parser_context_t *ctx, SaplingMetadata *obj);
+parser_error_t readOptionEpoch(parser_context_t *ctx, OptionEpoch *obj);
+parser_error_t readEpoch(parser_context_t *ctx, Epoch *obj);
+parser_error_t readDenomination(parser_context_t *ctx, Denomination *obj);
+parser_error_t readMaspDigitPos(parser_context_t *ctx, MaspDigitPos *obj);
+parser_error_t readAddressEstablished(parser_context_t *ctx, AddressEstablished *obj);
+parser_error_t readAddressImplicit(parser_context_t *ctx, AddressImplicit *obj);
+parser_error_t readAddressInternal(parser_context_t *ctx, AddressInternal *obj);
+parser_error_t readEstablishedAddress(parser_context_t *ctx, EstablishedAddress *obj);
+parser_error_t readImplicitAddress(parser_context_t *ctx, ImplicitAddress *obj);
+parser_error_t readInternalAddress(parser_context_t *ctx, InternalAddress *obj);
+parser_error_t readInternalAddressErc20(parser_context_t *ctx, InternalAddressErc20 *obj);
+parser_error_t readInternalAddressEthBridge(parser_context_t *ctx, InternalAddressEthBridge *obj);
+parser_error_t readInternalAddressEthBridgePool(parser_context_t *ctx, InternalAddressEthBridgePool *obj);
+parser_error_t readInternalAddressGovernance(parser_context_t *ctx, InternalAddressGovernance *obj);
+parser_error_t readInternalAddressIbc(parser_context_t *ctx, InternalAddressIbc *obj);
+parser_error_t readInternalAddressIbcToken(parser_context_t *ctx, InternalAddressIbcToken *obj);
+parser_error_t readInternalAddressMasp(parser_context_t *ctx, InternalAddressMasp *obj);
+parser_error_t readInternalAddressMultitoken(parser_context_t *ctx, InternalAddressMultitoken *obj);
+parser_error_t readInternalAddressNut(parser_context_t *ctx, InternalAddressNut *obj);
+parser_error_t readInternalAddressParameters(parser_context_t *ctx, InternalAddressParameters *obj);
+parser_error_t readInternalAddressPgf(parser_context_t *ctx, InternalAddressPgf *obj);
+parser_error_t readInternalAddressPoS(parser_context_t *ctx, InternalAddressPoS *obj);
+parser_error_t readInternalAddressPosSlashPool(parser_context_t *ctx, InternalAddressPosSlashPool *obj);
+parser_error_t readPublicKeyHash(parser_context_t *ctx, PublicKeyHash *obj);
+parser_error_t readEthAddress(parser_context_t *ctx, EthAddress *obj);
+parser_error_t readIbcTokenHash(parser_context_t *ctx, IbcTokenHash *obj);
+
 parser_error_t readUint128(parser_context_t *ctx, uint128_t *value) {
     if (value == NULL || ctx->offset + sizeof(uint128_t) > ctx->bufferLen) {
         return parser_unexpected_error;
@@ -85,31 +166,6 @@ parser_error_t readBytesAlt(parser_context_t *ctx, uint8_t *output, uint16_t out
     ctx->offset += outputLen;
     return parser_ok;
 }
-
-parser_error_t readAssetType_i128(parser_context_t *ctx, AssetType_i128 *obj);
-parser_error_t readAssetType(parser_context_t *ctx, AssetType *obj);
-parser_error_t readAuthorized(parser_context_t *ctx, Authorized *obj);
-parser_error_t readBlockHeight(parser_context_t *ctx, BlockHeight *obj);
-parser_error_t readBranchId(parser_context_t *ctx, BranchId *obj);
-parser_error_t readConvertDescriptionV5(parser_context_t *ctx, ConvertDescriptionV5 *obj);
-parser_error_t readEphemeralKeyBytes(parser_context_t *ctx, EphemeralKeyBytes *obj);
-parser_error_t readNullifier(parser_context_t *ctx, Nullifier *obj);
-parser_error_t readOutputDescriptionV5(parser_context_t *ctx, OutputDescriptionV5 *obj);
-parser_error_t readPublicKey(parser_context_t *ctx, PublicKey *obj);
-parser_error_t readSignature(parser_context_t *ctx, Signature *obj);
-parser_error_t readSpendDescriptionV5(parser_context_t *ctx, SpendDescriptionV5 *obj);
-parser_error_t readTransaction(parser_context_t *ctx, Transaction *obj);
-parser_error_t readCompactSize(parser_context_t *ctx, CompactSize *obj);
-parser_error_t readTransaction_authorization(parser_context_t *ctx, Transaction_authorization *obj, uint64_t sd_v5s_count, uint64_t cd_v5s_count, uint64_t od_v5s_count);
-parser_error_t readTransaction_convert_anchor(parser_context_t *ctx, Transaction_convert_anchor *obj, uint64_t cd_v5s_count);
-parser_error_t readTransaction_spend_anchor(parser_context_t *ctx, Transaction_spend_anchor *obj, uint64_t sd_v5s_count);
-parser_error_t readTransaction_value_balance(parser_context_t *ctx, Transaction_value_balance *obj, uint64_t sd_v5s_count, uint64_t cd_v5s_count, uint64_t od_v5s_count);
-parser_error_t readTransparentAddress(parser_context_t *ctx, TransparentAddress *obj);
-parser_error_t readTxInAuthorized(parser_context_t *ctx, TxInAuthorized *obj);
-parser_error_t readTxOut(parser_context_t *ctx, TxOut *obj);
-parser_error_t readTxVersion(parser_context_t *ctx, TxVersion *obj);
-parser_error_t readValueSumAssetType_i128(parser_context_t *ctx, ValueSumAssetType_i128 *obj);
-
 
 parser_error_t readAssetType_i128(parser_context_t *ctx, AssetType_i128 *obj) {
   CHECK_ERROR(readAssetType(ctx, &obj->f0))
@@ -366,264 +422,6 @@ parser_error_t readValueSumAssetType_i128(parser_context_t *ctx, ValueSumAssetTy
   }
   return parser_ok;
 }
-
-
-
-
-
-
-
-
-
-typedef struct {
-  uint8_t f0;
-  uint8_t f1[32];
-} u8_u8_32;
-
-typedef struct {
-  ValueSumAssetType_i128 assets;
-  uint8_t generator[32];
-} AllowedConversion;
-
-typedef struct {
-  uint8_t f0[32];
-} ChainCode;
-
-typedef struct {
-  uint32_t f0;
-} ChildIndex;
-
-typedef struct {
-  uint8_t auth_pathLen;
-  u8_u8_32 *auth_path;
-  uint64_t position;
-} MerklePathu8_32;
-
-typedef struct {
-  AllowedConversion allowed;
-  uint64_t value;
-  MerklePathu8_32 merkle_path;
-} ConvertDescriptionInfo;
-
-typedef struct {
-  uint8_t f0[11];
-} Diversifier;
-
-typedef struct {
-  uint8_t f0[32];
-} DiversifierKey;
-
-typedef struct {
-  uint8_t f0[32];
-} NullifierDerivingKey;
-
-typedef struct {
-  uint8_t ak[32];
-  NullifierDerivingKey nk;
-} ViewingKey;
-
-typedef struct {
-  uint8_t f0[32];
-} OutgoingViewingKey;
-
-typedef struct {
-  ViewingKey vk;
-  OutgoingViewingKey ovk;
-} FullViewingKey;
-
-typedef struct {
-  uint8_t f0[4];
-} FvkTag;
-
-typedef struct {
-  uint8_t depth;
-  FvkTag parent_fvk_tag;
-  ChildIndex child_index;
-  ChainCode chain_code;
-  FullViewingKey fvk;
-  DiversifierKey dk;
-} ExtendedFullViewingKey;
-
-typedef struct {
-  uint8_t f0[512];
-} MemoBytes;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  uint8_t BeforeZip212[32];
-  uint8_t AfterZip212[32];
-  };
-} Rseed;
-
-typedef struct {
-  AssetType asset_type;
-  uint64_t value;
-  uint8_t g_d[32];
-  uint8_t pk_d[32];
-  Rseed rseed;
-} Note;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  OutgoingViewingKey Some;
-  };
-} OptionOutgoingViewingKey;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  uint8_t Some[32];
-  };
-} Optionu8_32;
-
-typedef struct {
-  Diversifier diversifier;
-  uint8_t pk_d[32];
-} PaymentAddress;
-
-typedef struct {
-  ExtendedFullViewingKey extsk;
-  Diversifier diversifier;
-  Note note;
-  uint8_t alpha[32];
-  MerklePathu8_32 merkle_path;
-} SpendDescriptionInfoExtendedFullViewingKey;
-
-typedef struct {
-  OptionOutgoingViewingKey ovk;
-  PaymentAddress to;
-  Note note;
-  MemoBytes memo;
-} SaplingOutputInfo;
-
-typedef struct {
-  Optionu8_32 spend_anchor;
-  BlockHeight target_height;
-  ValueSumAssetType_i128 value_balance;
-  Optionu8_32 convert_anchor;
-  uint32_t spendsLen;
-  SpendDescriptionInfoExtendedFullViewingKey *spends;
-  uint32_t convertsLen;
-  ConvertDescriptionInfo *converts;
-  uint32_t outputsLen;
-  SaplingOutputInfo *outputs;
-} SaplingBuilder_ExtendedFullViewingKey;
-
-typedef struct {
-  TxOut coin;
-} TransparentInputInfo;
-
-typedef struct {
-  uint32_t inputsLen;
-  TransparentInputInfo *inputs;
-  uint32_t voutLen;
-  TxOut *vout;
-} TransparentBuilder;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  uint16_t u16;
-  uint32_t u32;
-  uint64_t u64;
-  };
-} ValueSumAssetType_i128_CompactSize;
-
-typedef struct {
-  BlockHeight target_height;
-  BlockHeight expiry_height;
-  TransparentBuilder transparent_builder;
-  SaplingBuilder_ExtendedFullViewingKey sapling_builder;
-} Builder__ExtendedFullViewingKey;
-
-typedef struct {
-  uint8_t f0[32];
-} Hash;
-
-typedef struct {
-  uint32_t spend_indicesLen;
-  uint64_t *spend_indices;
-  uint32_t convert_indicesLen;
-  uint64_t *convert_indices;
-  uint32_t output_indicesLen;
-  uint64_t *output_indices;
-} SaplingMetadata;
-
-typedef struct {
-  uint8_t bytes[ADDRESS_LEN_BYTES];
-} AddressAlt;
-
-typedef struct {
-  uint64_t f0;
-} Epoch;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  Epoch Some;
-  };
-} OptionEpoch;
-
-typedef struct {
-  uint8_t f0;
-} Denomination;
-
-typedef struct {
-  uint8_t tag;
-} MaspDigitPos;
-
-typedef struct {
-  AddressAlt token;
-  Denomination denom;
-  MaspDigitPos position;
-  OptionEpoch epoch;
-} AssetData;
-
-typedef struct {
-  Hash target;
-  uint32_t asset_typesLen;
-  AssetData *asset_types;
-  SaplingMetadata metadata;
-  Builder__ExtendedFullViewingKey builder;
-} MaspBuilder;
-
-parser_error_t readu8_u8_32(parser_context_t *ctx, u8_u8_32 *obj);
-parser_error_t readAllowedConversion(parser_context_t *ctx, AllowedConversion *obj);
-parser_error_t readBuilder__ExtendedFullViewingKey(parser_context_t *ctx, Builder__ExtendedFullViewingKey *obj);
-parser_error_t readChainCode(parser_context_t *ctx, ChainCode *obj);
-parser_error_t readChildIndex(parser_context_t *ctx, ChildIndex *obj);
-parser_error_t readConvertDescriptionInfo(parser_context_t *ctx, ConvertDescriptionInfo *obj);
-parser_error_t readDiversifier(parser_context_t *ctx, Diversifier *obj);
-parser_error_t readDiversifierKey(parser_context_t *ctx, DiversifierKey *obj);
-parser_error_t readExtendedFullViewingKey(parser_context_t *ctx, ExtendedFullViewingKey *obj);
-parser_error_t readFullViewingKey(parser_context_t *ctx, FullViewingKey *obj);
-parser_error_t readFvkTag(parser_context_t *ctx, FvkTag *obj);
-parser_error_t readMemoBytes(parser_context_t *ctx, MemoBytes *obj);
-parser_error_t readMerklePathu8_32(parser_context_t *ctx, MerklePathu8_32 *obj);
-parser_error_t readNote(parser_context_t *ctx, Note *obj);
-parser_error_t readNullifierDerivingKey(parser_context_t *ctx, NullifierDerivingKey *obj);
-parser_error_t readOptionOutgoingViewingKey(parser_context_t *ctx, OptionOutgoingViewingKey *obj);
-parser_error_t readOptionu8_32(parser_context_t *ctx, Optionu8_32 *obj);
-parser_error_t readOutgoingViewingKey(parser_context_t *ctx, OutgoingViewingKey *obj);
-parser_error_t readPaymentAddress(parser_context_t *ctx, PaymentAddress *obj);
-parser_error_t readRseed(parser_context_t *ctx, Rseed *obj);
-parser_error_t readSaplingBuilder_ExtendedFullViewingKey(parser_context_t *ctx, SaplingBuilder_ExtendedFullViewingKey *obj);
-parser_error_t readSaplingOutputInfo(parser_context_t *ctx, SaplingOutputInfo *obj);
-parser_error_t readSpendDescriptionInfoExtendedFullViewingKey(parser_context_t *ctx, SpendDescriptionInfoExtendedFullViewingKey *obj);
-parser_error_t readTransparentBuilder(parser_context_t *ctx, TransparentBuilder *obj);
-parser_error_t readTransparentInputInfo(parser_context_t *ctx, TransparentInputInfo *obj);
-parser_error_t readValueSumAssetType_i128_CompactSize(parser_context_t *ctx, ValueSumAssetType_i128_CompactSize *obj);
-parser_error_t readViewingKey(parser_context_t *ctx, ViewingKey *obj);
-parser_error_t readMaspBuilder(parser_context_t *ctx, MaspBuilder *obj);
-parser_error_t readHash(parser_context_t *ctx, Hash *obj);
-parser_error_t readAssetData(parser_context_t *ctx, AssetData *obj);
-parser_error_t readSaplingMetadata(parser_context_t *ctx, SaplingMetadata *obj);
-parser_error_t readOptionEpoch(parser_context_t *ctx, OptionEpoch *obj);
-parser_error_t readEpoch(parser_context_t *ctx, Epoch *obj);
-parser_error_t readDenomination(parser_context_t *ctx, Denomination *obj);
-parser_error_t readMaspDigitPos(parser_context_t *ctx, MaspDigitPos *obj);
 
 parser_error_t readu8_u8_32(parser_context_t *ctx, u8_u8_32 *obj) {
   CHECK_ERROR(readByte(ctx, &obj->f0))
@@ -893,8 +691,145 @@ parser_error_t readSaplingMetadata(parser_context_t *ctx, SaplingMetadata *obj) 
   return parser_ok;
 }
 
+parser_error_t readEstablishedAddress(parser_context_t *ctx, EstablishedAddress *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->hash, 20))
+  return parser_ok;
+}
+
+parser_error_t readAddressEstablished(parser_context_t *ctx, AddressEstablished *obj) {
+  CHECK_ERROR(readEstablishedAddress(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readImplicitAddress(parser_context_t *ctx, ImplicitAddress *obj) {
+  CHECK_ERROR(readPublicKeyHash(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readAddressImplicit(parser_context_t *ctx, AddressImplicit *obj) {
+  CHECK_ERROR(readImplicitAddress(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readInternalAddress(parser_context_t *ctx, InternalAddress *obj) {
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 0:
+  CHECK_ERROR(readInternalAddressPoS(ctx, &obj->PoS))
+  break;
+  case 1:
+  CHECK_ERROR(readInternalAddressPosSlashPool(ctx, &obj->PosSlashPool))
+  break;
+  case 2:
+  CHECK_ERROR(readInternalAddressParameters(ctx, &obj->Parameters))
+  break;
+  case 3:
+  CHECK_ERROR(readInternalAddressIbc(ctx, &obj->Ibc))
+  break;
+  case 4:
+  CHECK_ERROR(readInternalAddressIbcToken(ctx, &obj->IbcToken))
+  break;
+  case 5:
+  CHECK_ERROR(readInternalAddressGovernance(ctx, &obj->Governance))
+  break;
+  case 6:
+  CHECK_ERROR(readInternalAddressEthBridge(ctx, &obj->EthBridge))
+  break;
+  case 7:
+  CHECK_ERROR(readInternalAddressEthBridgePool(ctx, &obj->EthBridgePool))
+  break;
+  case 8:
+  CHECK_ERROR(readInternalAddressErc20(ctx, &obj->Erc20))
+  break;
+  case 9:
+  CHECK_ERROR(readInternalAddressNut(ctx, &obj->Nut))
+  break;
+  case 10:
+  CHECK_ERROR(readInternalAddressMultitoken(ctx, &obj->Multitoken))
+  break;
+  case 11:
+  CHECK_ERROR(readInternalAddressPgf(ctx, &obj->Pgf))
+  break;
+  case 12:
+  CHECK_ERROR(readInternalAddressMasp(ctx, &obj->Masp))
+  break;
+  }
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressErc20(parser_context_t *ctx, InternalAddressErc20 *obj) {
+  CHECK_ERROR(readEthAddress(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressEthBridge(parser_context_t *ctx, InternalAddressEthBridge *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressEthBridgePool(parser_context_t *ctx, InternalAddressEthBridgePool *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressGovernance(parser_context_t *ctx, InternalAddressGovernance *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressIbc(parser_context_t *ctx, InternalAddressIbc *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressIbcToken(parser_context_t *ctx, InternalAddressIbcToken *obj) {
+  CHECK_ERROR(readIbcTokenHash(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressMasp(parser_context_t *ctx, InternalAddressMasp *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressMultitoken(parser_context_t *ctx, InternalAddressMultitoken *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressNut(parser_context_t *ctx, InternalAddressNut *obj) {
+  CHECK_ERROR(readEthAddress(ctx, &obj->f0))
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressParameters(parser_context_t *ctx, InternalAddressParameters *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressPgf(parser_context_t *ctx, InternalAddressPgf *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressPoS(parser_context_t *ctx, InternalAddressPoS *obj) {
+  return parser_ok;
+}
+
+parser_error_t readInternalAddressPosSlashPool(parser_context_t *ctx, InternalAddressPosSlashPool *obj) {
+  return parser_ok;
+}
+
+parser_error_t readAddressInternal(parser_context_t *ctx, AddressInternal *obj) {
+  CHECK_ERROR(readInternalAddress(ctx, &obj->f0))
+  return parser_ok;
+}
+
 parser_error_t readAddressAlt(parser_context_t *ctx, AddressAlt *obj) {
-  CHECK_ERROR(readBytesAlt(ctx, obj->bytes, ADDRESS_LEN_BYTES))
+  CHECK_ERROR(readByte(ctx, &obj->tag))
+  switch(obj->tag) {
+  case 0:
+  CHECK_ERROR(readAddressEstablished(ctx, &obj->Established))
+  break;
+  case 1:
+  CHECK_ERROR(readAddressImplicit(ctx, &obj->Implicit))
+  break;
+  case 2:
+  CHECK_ERROR(readAddressInternal(ctx, &obj->Internal))
+  break;
+  }
   return parser_ok;
 }
 
@@ -947,13 +882,20 @@ parser_error_t readMaspDigitPos(parser_context_t *ctx, MaspDigitPos *obj) {
   return parser_ok;
 }
 
+parser_error_t readPublicKeyHash(parser_context_t *ctx, PublicKeyHash *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 20))
+  return parser_ok;
+}
 
+parser_error_t readEthAddress(parser_context_t *ctx, EthAddress *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 20))
+  return parser_ok;
+}
 
-
-
-
-
-
+parser_error_t readIbcTokenHash(parser_context_t *ctx, IbcTokenHash *obj) {
+  CHECK_ERROR(readBytesAlt(ctx, obj->f0, 20))
+  return parser_ok;
+}
 
 parser_error_t readToken(const bytes_t *token, const char **symbol) {
     if (token == NULL || symbol == NULL) {
@@ -2118,7 +2060,7 @@ static parser_error_t readMaspTx(parser_context_t *ctx, masp_tx_section_t *maspT
     return parser_ok;
 }
 
-static parser_error_t readMaspBuilderSection(parser_context_t *ctx, section_t *maspBuilder) {
+static parser_error_t readMaspBuilderSection(parser_context_t *ctx, MaspBuilder *maspBuilder) {
     if (ctx == NULL) {
         return parser_unexpected_error;
     }
@@ -2127,8 +2069,7 @@ static parser_error_t readMaspBuilderSection(parser_context_t *ctx, section_t *m
     if (discriminant != DISCRIMINANT_MASP_BUILDER) {
         return parser_unexpected_value;
     }
-    MaspBuilder mb;
-    CHECK_ERROR(readMaspBuilder(ctx, &mb))
+    CHECK_ERROR(readMaspBuilder(ctx, maspBuilder))
     return parser_ok;
 }
 
@@ -2193,7 +2134,7 @@ parser_error_t readSections(parser_context_t *ctx, parser_tx_t *v) {
                 break;
 
             case DISCRIMINANT_MASP_BUILDER:
-                CHECK_ERROR(readMaspBuilderSection(ctx, NULL))
+                CHECK_ERROR(readMaspBuilderSection(ctx, &v->transaction.sections.maspBuilder))
                 break;
 #if(0)
             case DISCRIMINANT_CIPHERTEXT:

--- a/app/src/parser_print_common.c
+++ b/app/src/parser_print_common.c
@@ -91,7 +91,7 @@ parser_error_t printAddress( bytes_t pubkeyHash,
     return parser_ok;
 }
 
-parser_error_t printAddressAlt( AddressAlt *addr,
+parser_error_t printAddressAlt( const AddressAlt *addr,
                              char *outVal, uint16_t outValLen,
                              uint8_t pageIdx, uint8_t *pageCount) {
 
@@ -288,13 +288,13 @@ parser_error_t printProposal(const tx_init_proposal_t *initProposal, uint8_t dis
 
     } else if (initProposal->proposal_type == PGFSteward) {
         uint8_t add_rem_discriminant = 0;
-        bytes_t tmpBytes = {.ptr = NULL, .len = ADDRESS_LEN_BYTES};
+        AddressAlt tmpBytes;
         parser_context_t tmpCtx = { .buffer = initProposal->pgf_steward_actions.ptr,
                                     .bufferLen = initProposal->pgf_steward_actions.len,
                                     .offset = 0};
         for (uint32_t i = 0; i < displayIdx; i++) {
             CHECK_ERROR(readByte(&tmpCtx, &add_rem_discriminant))
-            CHECK_ERROR(readBytes(&tmpCtx, &tmpBytes.ptr, tmpBytes.len))
+            CHECK_ERROR(readAddressAlt(&tmpCtx, &tmpBytes))
         }
 
         // Add = 0 | Remove = 1
@@ -303,7 +303,7 @@ parser_error_t printProposal(const tx_init_proposal_t *initProposal, uint8_t dis
             snprintf(outKey, outKeyLen, "Remove");
         }
 
-        CHECK_ERROR(printAddress(tmpBytes, outVal, outValLen, pageIdx, pageCount))
+        CHECK_ERROR(printAddressAlt(&tmpBytes, outVal, outValLen, pageIdx, pageCount))
 
     } else if (initProposal->proposal_type == PGFPayment) {
         pgf_payment_action_t pgfPayment = {0};
@@ -340,7 +340,7 @@ parser_error_t printProposal(const tx_init_proposal_t *initProposal, uint8_t dis
 
                 case 1:
                     snprintf(outKey, outKeyLen, "Target");
-                    CHECK_ERROR(printAddress(pgfPayment.internal.address, outVal, outValLen, pageIdx, pageCount))
+                    CHECK_ERROR(printAddressAlt(&pgfPayment.internal.address, outVal, outValLen, pageIdx, pageCount))
                     break;
 
                 case 0:
@@ -447,7 +447,7 @@ parser_error_t printExpert( const parser_context_t *ctx,
                 CHECK_ERROR(printAmount(&ctx->tx_obj->transaction.header.fees.amount, true, ctx->tx_obj->transaction.header.fees.denom, "", outVal, outValLen, pageIdx, pageCount))
             } else {
                 snprintf(outKey, outKeyLen, "Fee token");
-                CHECK_ERROR(printAddress(ctx->tx_obj->transaction.header.fees.address, outVal, outValLen, pageIdx, pageCount))
+                CHECK_ERROR(printAddressAlt(&ctx->tx_obj->transaction.header.fees.address, outVal, outValLen, pageIdx, pageCount))
             }
             break;
         }

--- a/app/src/parser_print_common.c
+++ b/app/src/parser_print_common.c
@@ -91,6 +91,17 @@ parser_error_t printAddress( bytes_t pubkeyHash,
     return parser_ok;
 }
 
+parser_error_t printAddressAlt( AddressAlt *addr,
+                             char *outVal, uint16_t outValLen,
+                             uint8_t pageIdx, uint8_t *pageCount) {
+
+    char address[110] = {0};
+    CHECK_ERROR(encodeAddress(addr, address, sizeof(address)))
+    pageString(outVal, outValLen, (const char*) address, pageIdx, pageCount);
+
+    return parser_ok;
+}
+
 parser_error_t printCodeHash(section_t *codeSection,
                              char *outKey, uint16_t outKeyLen,
                              char *outVal, uint16_t outValLen,

--- a/app/src/parser_print_common.h
+++ b/app/src/parser_print_common.h
@@ -50,6 +50,10 @@ parser_error_t printAddress(bytes_t pubkeyHash,
                             char *outVal, uint16_t outValLen,
                             uint8_t pageIdx, uint8_t *pageCount);
 
+parser_error_t printAddressAlt(AddressAlt *addr,
+                            char *outVal, uint16_t outValLen,
+                            uint8_t pageIdx, uint8_t *pageCount);
+
 parser_error_t printAmount( const bytes_t *amount, bool isSigned, uint8_t amountDenom, const char* symbol,
                             char *outVal, uint16_t outValLen,
                             uint8_t pageIdx, uint8_t *pageCount);

--- a/app/src/parser_print_common.h
+++ b/app/src/parser_print_common.h
@@ -50,7 +50,7 @@ parser_error_t printAddress(bytes_t pubkeyHash,
                             char *outVal, uint16_t outValLen,
                             uint8_t pageIdx, uint8_t *pageCount);
 
-parser_error_t printAddressAlt(AddressAlt *addr,
+parser_error_t printAddressAlt(const AddressAlt *addr,
                             char *outVal, uint16_t outValLen,
                             uint8_t pageIdx, uint8_t *pageCount);
 

--- a/app/src/parser_print_txn.c
+++ b/app/src/parser_print_txn.c
@@ -145,11 +145,11 @@ static parser_error_t printTransferTxn( const parser_context_t *ctx,
             break;
         case 1:
             snprintf(outKey, outKeyLen, "Sender");
-            CHECK_ERROR(printAddress(ctx->tx_obj->transfer.source_address, outVal, outValLen, pageIdx, pageCount))
+            CHECK_ERROR(printAddressAlt(&ctx->tx_obj->transfer.source_address, outVal, outValLen, pageIdx, pageCount))
             break;
         case 2:
             snprintf(outKey, outKeyLen, "Destination");
-            CHECK_ERROR(printAddress(ctx->tx_obj->transfer.target_address, outVal, outValLen, pageIdx, pageCount))
+            CHECK_ERROR(printAddressAlt(&ctx->tx_obj->transfer.target_address, outVal, outValLen, pageIdx, pageCount))
             break;
         case 3:
             if(ctx->tx_obj->transfer.symbol != NULL) {

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -60,7 +60,8 @@ typedef struct {
     uint8_t idx;
     concatenated_hashes_t hashes;
     signer_discriminant_e signerDiscriminant;
-    bytes_t address;
+    AddressAlt address;
+  bytes_t addressBytes;
     uint32_t pubKeysLen;
     bytes_t pubKeys;
     uint32_t signaturesLen;

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -282,6 +282,308 @@ typedef struct {
 } masp_tx_section_t;
 
 typedef struct {
+  uint8_t f0[20];
+} IbcTokenHash;
+
+typedef struct {
+  uint8_t f0[20];
+} EthAddress;
+
+typedef struct {
+  uint8_t f0[20];
+} PublicKeyHash;
+
+typedef struct {
+  uint8_t f0;
+  uint8_t f1[32];
+} u8_u8_32;
+
+typedef struct {
+  ValueSumAssetType_i128 assets;
+  uint8_t generator[32];
+} AllowedConversion;
+
+typedef struct {
+  uint8_t f0[32];
+} ChainCode;
+
+typedef struct {
+  uint32_t f0;
+} ChildIndex;
+
+typedef struct {
+  uint8_t auth_pathLen;
+  u8_u8_32 *auth_path;
+  uint64_t position;
+} MerklePathu8_32;
+
+typedef struct {
+  AllowedConversion allowed;
+  uint64_t value;
+  MerklePathu8_32 merkle_path;
+} ConvertDescriptionInfo;
+
+typedef struct {
+  uint8_t f0[11];
+} Diversifier;
+
+typedef struct {
+  uint8_t f0[32];
+} DiversifierKey;
+
+typedef struct {
+  uint8_t f0[32];
+} NullifierDerivingKey;
+
+typedef struct {
+  uint8_t ak[32];
+  NullifierDerivingKey nk;
+} ViewingKey;
+
+typedef struct {
+  uint8_t f0[32];
+} OutgoingViewingKey;
+
+typedef struct {
+  ViewingKey vk;
+  OutgoingViewingKey ovk;
+} FullViewingKey;
+
+typedef struct {
+  uint8_t f0[4];
+} FvkTag;
+
+typedef struct {
+  uint8_t depth;
+  FvkTag parent_fvk_tag;
+  ChildIndex child_index;
+  ChainCode chain_code;
+  FullViewingKey fvk;
+  DiversifierKey dk;
+} ExtendedFullViewingKey;
+
+typedef struct {
+  uint8_t f0[512];
+} MemoBytes;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint8_t BeforeZip212[32];
+  uint8_t AfterZip212[32];
+  };
+} Rseed;
+
+typedef struct {
+  AssetType asset_type;
+  uint64_t value;
+  uint8_t g_d[32];
+  uint8_t pk_d[32];
+  Rseed rseed;
+} Note;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  OutgoingViewingKey Some;
+  };
+} OptionOutgoingViewingKey;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint8_t Some[32];
+  };
+} Optionu8_32;
+
+typedef struct {
+  Diversifier diversifier;
+  uint8_t pk_d[32];
+} PaymentAddress;
+
+typedef struct {
+  ExtendedFullViewingKey extsk;
+  Diversifier diversifier;
+  Note note;
+  uint8_t alpha[32];
+  MerklePathu8_32 merkle_path;
+} SpendDescriptionInfoExtendedFullViewingKey;
+
+typedef struct {
+  OptionOutgoingViewingKey ovk;
+  PaymentAddress to;
+  Note note;
+  MemoBytes memo;
+} SaplingOutputInfo;
+
+typedef struct {
+  Optionu8_32 spend_anchor;
+  BlockHeight target_height;
+  ValueSumAssetType_i128 value_balance;
+  Optionu8_32 convert_anchor;
+  uint32_t spendsLen;
+  SpendDescriptionInfoExtendedFullViewingKey *spends;
+  uint32_t convertsLen;
+  ConvertDescriptionInfo *converts;
+  uint32_t outputsLen;
+  SaplingOutputInfo *outputs;
+} SaplingBuilder_ExtendedFullViewingKey;
+
+typedef struct {
+  TxOut coin;
+} TransparentInputInfo;
+
+typedef struct {
+  uint32_t inputsLen;
+  TransparentInputInfo *inputs;
+  uint32_t voutLen;
+  TxOut *vout;
+} TransparentBuilder;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+  };
+} ValueSumAssetType_i128_CompactSize;
+
+typedef struct {
+  BlockHeight target_height;
+  BlockHeight expiry_height;
+  TransparentBuilder transparent_builder;
+  SaplingBuilder_ExtendedFullViewingKey sapling_builder;
+} Builder__ExtendedFullViewingKey;
+
+typedef struct {
+  uint8_t f0[32];
+} Hash;
+
+typedef struct {
+  uint32_t spend_indicesLen;
+  uint64_t *spend_indices;
+  uint32_t convert_indicesLen;
+  uint64_t *convert_indices;
+  uint32_t output_indicesLen;
+  uint64_t *output_indices;
+} SaplingMetadata;
+
+typedef struct {
+  uint8_t hash[20];
+} EstablishedAddress;
+
+typedef struct {
+  EstablishedAddress f0;
+} AddressEstablished;
+
+typedef struct {
+  PublicKeyHash f0;
+} ImplicitAddress;
+
+typedef struct {
+  ImplicitAddress f0;
+} AddressImplicit;
+
+typedef struct {
+  EthAddress f0;
+} InternalAddressErc20;
+
+typedef struct {} InternalAddressEthBridge;
+
+typedef struct {} InternalAddressEthBridgePool;
+
+typedef struct {} InternalAddressGovernance;
+
+typedef struct {} InternalAddressIbc;
+
+typedef struct {
+  IbcTokenHash f0;
+} InternalAddressIbcToken;
+
+typedef struct {} InternalAddressMasp;
+
+typedef struct {} InternalAddressMultitoken;
+
+typedef struct {
+  EthAddress f0;
+} InternalAddressNut;
+
+typedef struct {} InternalAddressParameters;
+
+typedef struct {} InternalAddressPgf;
+
+typedef struct {} InternalAddressPoS;
+
+typedef struct {} InternalAddressPosSlashPool;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  InternalAddressPoS PoS;
+  InternalAddressPosSlashPool PosSlashPool;
+  InternalAddressParameters Parameters;
+  InternalAddressIbc Ibc;
+  InternalAddressIbcToken IbcToken;
+  InternalAddressGovernance Governance;
+  InternalAddressEthBridge EthBridge;
+  InternalAddressEthBridgePool EthBridgePool;
+  InternalAddressErc20 Erc20;
+  InternalAddressNut Nut;
+  InternalAddressMultitoken Multitoken;
+  InternalAddressPgf Pgf;
+  InternalAddressMasp Masp;
+  };
+} InternalAddress;
+
+typedef struct {
+  InternalAddress f0;
+} AddressInternal;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  AddressEstablished Established;
+  AddressImplicit Implicit;
+  AddressInternal Internal;
+  };
+} AddressAlt;
+
+typedef struct {
+  uint64_t f0;
+} Epoch;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  Epoch Some;
+  };
+} OptionEpoch;
+
+typedef struct {
+  uint8_t f0;
+} Denomination;
+
+typedef struct {
+  uint8_t tag;
+} MaspDigitPos;
+
+typedef struct {
+  AddressAlt token;
+  Denomination denom;
+  MaspDigitPos position;
+  OptionEpoch epoch;
+} AssetData;
+
+typedef struct {
+  Hash target;
+  uint32_t asset_typesLen;
+  AssetData *asset_types;
+  SaplingMetadata metadata;
+  Builder__ExtendedFullViewingKey builder;
+} MaspBuilder;
+
+typedef struct {
     uint8_t discriminant;
     bytes_t salt;
     uint8_t commitmentDiscriminant;
@@ -313,9 +615,9 @@ typedef struct {
     section_t extraData[MAX_EXTRA_DATA_SECS];
     signature_section_t signatures[MAX_SIGNATURE_SECS];
     masp_tx_section_t maspTx;
+    MaspBuilder maspBuilder;
 #if(0)
     section_t ciphertext; // todo: if we need to parse this in future, it will not be a section_t
-    section_t maspBuilder; // todo: if we need to parse this in future, it will not be a section_t
 #endif
 } sections_t;
 

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -122,12 +122,164 @@ typedef struct {
     uint8_t has_sapling_bundle;
     masp_sapling_bundle_t sapling_bundle;
 } masp_tx_data_t;
+#endif
+
+typedef struct {
+  uint64_t lo;
+  int64_t hi;
+} int128_t;
+
+typedef struct {
+  uint64_t lo;
+  uint64_t hi;
+} uint128_t;
+
+typedef struct {
+  uint8_t identifier[32];
+} AssetType;
+
+typedef struct {
+  AssetType f0;
+  int128_t f1;
+} AssetType_i128;
+
+typedef struct {
+  uint32_t f0;
+} BlockHeight;
+
+typedef struct {
+  uint32_t tag;
+  union {
+  };
+} BranchId;
+
+typedef struct {
+  uint8_t cv[32];
+} ConvertDescriptionV5;
+
+typedef struct {
+  uint8_t f0[32];
+} EphemeralKeyBytes;
+
+typedef struct {
+  uint8_t f0[32];
+} Nullifier;
+
+typedef struct {
+  uint8_t cv[32];
+  uint8_t cmu[32];
+  EphemeralKeyBytes ephemeral_key;
+  uint8_t enc_ciphertext[612];
+  uint8_t out_ciphertext[80];
+} OutputDescriptionV5;
+
+typedef struct {
+  uint8_t f0[32];
+} PublicKey;
+
+typedef struct {
+  uint8_t rbar[32];
+  uint8_t sbar[32];
+} Signature;
+
+typedef struct {
+  Signature binding_sig;
+} Authorized;
+
+typedef struct {
+  uint8_t cv[32];
+  Nullifier nullifier;
+  PublicKey rk;
+} SpendDescriptionV5;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  uint16_t u16;
+  uint32_t u32;
+  uint64_t u64;
+  };
+} CompactSize;
+
+typedef struct {
+  union {
+  Authorized Some;
+  };
+} Transaction_authorization;
+
+typedef struct {
+  union {
+  uint8_t Some[32];
+  };
+} Transaction_convert_anchor;
+
+typedef struct {
+  union {
+  uint8_t Some[32];
+  };
+} Transaction_spend_anchor;
+
+typedef struct {
+  uint8_t f0[20];
+} TransparentAddress;
+
+typedef struct {
+  AssetType asset_type;
+  uint64_t value;
+  TransparentAddress address;
+} TxInAuthorized;
+
+typedef struct {
+  AssetType asset_type;
+  uint64_t value;
+  TransparentAddress address;
+} TxOut;
+
+typedef struct {
+  uint32_t header;
+  uint32_t version_group_id;
+} TxVersion;
+
+typedef struct {
+  CompactSize f0;
+  AssetType_i128 *f1;
+} ValueSumAssetType_i128;
+
+typedef struct {
+  union {
+  ValueSumAssetType_i128 Some;
+  };
+} Transaction_value_balance;
+
+typedef struct {
+  TxVersion version;
+  BranchId consensus_branch_id;
+  uint32_t lock_time;
+  BlockHeight expiry_height;
+  CompactSize vin_count;
+  TxInAuthorized *vin;
+  CompactSize vout_count;
+  TxOut *vout;
+  CompactSize sd_v5s_count;
+  SpendDescriptionV5 *sd_v5s;
+  CompactSize cd_v5s_count;
+  ConvertDescriptionV5 *cd_v5s;
+  CompactSize od_v5s_count;
+  OutputDescriptionV5 *od_v5s;
+  Transaction_value_balance value_balance;
+  Transaction_spend_anchor spend_anchor;
+  Transaction_convert_anchor convert_anchor;
+  uint8_t (*v_spend_proofs)[192];
+  Signature *v_spend_auth_sigs;
+  uint8_t (*v_convert_proofs)[192];
+  uint8_t (*v_output_proofs)[192];
+  Transaction_authorization authorization;
+} Transaction;
 
 typedef struct {
     bytes_t tx_id; // [u8;32]
-    masp_tx_data_t data;
+  Transaction data;
 } masp_tx_section_t;
-#endif
 
 typedef struct {
     uint8_t discriminant;
@@ -160,9 +312,9 @@ typedef struct {
     section_t data;
     section_t extraData[MAX_EXTRA_DATA_SECS];
     signature_section_t signatures[MAX_SIGNATURE_SECS];
+    masp_tx_section_t maspTx;
 #if(0)
     section_t ciphertext; // todo: if we need to parse this in future, it will not be a section_t
-    masp_tx_section_t maspTx;
     section_t maspBuilder; // todo: if we need to parse this in future, it will not be a section_t
 #endif
 } sections_t;

--- a/app/src/parser_txdef.h
+++ b/app/src/parser_txdef.h
@@ -282,18 +282,6 @@ typedef struct {
 } masp_tx_section_t;
 
 typedef struct {
-  uint8_t f0[20];
-} IbcTokenHash;
-
-typedef struct {
-  uint8_t f0[20];
-} EthAddress;
-
-typedef struct {
-  uint8_t f0[20];
-} PublicKeyHash;
-
-typedef struct {
   uint8_t f0;
   uint8_t f1[32];
 } u8_u8_32;
@@ -468,86 +456,6 @@ typedef struct {
   uint32_t output_indicesLen;
   uint64_t *output_indices;
 } SaplingMetadata;
-
-typedef struct {
-  uint8_t hash[20];
-} EstablishedAddress;
-
-typedef struct {
-  EstablishedAddress f0;
-} AddressEstablished;
-
-typedef struct {
-  PublicKeyHash f0;
-} ImplicitAddress;
-
-typedef struct {
-  ImplicitAddress f0;
-} AddressImplicit;
-
-typedef struct {
-  EthAddress f0;
-} InternalAddressErc20;
-
-typedef struct {} InternalAddressEthBridge;
-
-typedef struct {} InternalAddressEthBridgePool;
-
-typedef struct {} InternalAddressGovernance;
-
-typedef struct {} InternalAddressIbc;
-
-typedef struct {
-  IbcTokenHash f0;
-} InternalAddressIbcToken;
-
-typedef struct {} InternalAddressMasp;
-
-typedef struct {} InternalAddressMultitoken;
-
-typedef struct {
-  EthAddress f0;
-} InternalAddressNut;
-
-typedef struct {} InternalAddressParameters;
-
-typedef struct {} InternalAddressPgf;
-
-typedef struct {} InternalAddressPoS;
-
-typedef struct {} InternalAddressPosSlashPool;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  InternalAddressPoS PoS;
-  InternalAddressPosSlashPool PosSlashPool;
-  InternalAddressParameters Parameters;
-  InternalAddressIbc Ibc;
-  InternalAddressIbcToken IbcToken;
-  InternalAddressGovernance Governance;
-  InternalAddressEthBridge EthBridge;
-  InternalAddressEthBridgePool EthBridgePool;
-  InternalAddressErc20 Erc20;
-  InternalAddressNut Nut;
-  InternalAddressMultitoken Multitoken;
-  InternalAddressPgf Pgf;
-  InternalAddressMasp Masp;
-  };
-} InternalAddress;
-
-typedef struct {
-  InternalAddress f0;
-} AddressInternal;
-
-typedef struct {
-  uint8_t tag;
-  union {
-  AddressEstablished Established;
-  AddressImplicit Implicit;
-  AddressInternal Internal;
-  };
-} AddressAlt;
 
 typedef struct {
   uint64_t f0;

--- a/app/src/parser_types.h
+++ b/app/src/parser_types.h
@@ -99,163 +99,6 @@ typedef struct {
 } bytes_t;
 
 typedef struct {
-    uint8_t *ptr;
-    uint32_t len;
-} mut_bytes_t;
-
-typedef struct {
-    bytes_t address;
-    bytes_t amount;
-} pgf_internal_t;
-
-typedef struct {
-    bytes_t target;
-    bytes_t amount;
-    bytes_t portId;
-    bytes_t channelId;
-} pgf_ibc_t;
-typedef struct {
-    pgf_action_e action;
-    pgf_continuous_type_e add_rem;
-    pgf_target_type_e targetType;
-    union {
-        pgf_internal_t internal;
-        pgf_ibc_t ibc;
-    };
-    uint16_t length;
-} pgf_payment_action_t;
-
-typedef struct {
-    uint64_t proposal_id;
-    bytes_t content_hash;
-    bytes_t content_sechash;
-    bytes_t author;
-    uint64_t voting_start_epoch;
-    uint64_t voting_end_epoch;
-    uint64_t grace_epoch;
-    uint8_t proposal_type;
-    union {
-        struct {
-            uint8_t has_proposal_code;
-            bytes_t proposal_code_sechash;
-            bytes_t proposal_code_hash;
-        };
-        struct {
-            uint32_t pgf_steward_actions_num;
-            bytes_t pgf_steward_actions;
-        };
-        struct {
-            uint32_t pgf_payment_actions_num;
-            uint32_t pgf_payment_ibc_num;
-            bytes_t pgf_payment_actions;
-        };
-    };
-
-    uint8_t content_secidx;
-    uint8_t proposal_code_secidx;
-} tx_init_proposal_t;
-
-
-typedef struct {
-    uint64_t millis;
-    uint32_t nanos;
-} timestamp_t;
-
-typedef struct {
-    bytes_t council_address;
-    bytes_t amount;
-} council_t;
-
-typedef struct {
-    uint64_t proposal_id;
-    proposal_vote_e proposal_vote;
-    yay_vote_type_e vote_type;
-    uint32_t number_of_councils;
-    bytes_t councils;
-    bytes_t eth_bridge_signature;
-    // proposal author address
-    bytes_t voter;
-    // Delegator addresses
-    uint32_t number_of_delegations;
-    bytes_t delegations;
-} tx_vote_proposal_t;
-
-typedef struct {
-    uint32_t number_of_pubkeys;
-    bytes_t pubkeys;
-    uint8_t threshold;
-    bytes_t vp_type_sechash;
-    bytes_t vp_type_hash;
-    uint8_t vp_type_secidx;
-    const char* vp_type_text;
-} tx_init_account_t;
-
-typedef struct {
-    bytes_t validator;
-    bytes_t amount;
-    uint8_t has_source;
-    bytes_t source;
-} tx_bond_t;
-
-typedef struct {
-    bytes_t src_validator;
-    bytes_t dest_validator;
-    bytes_t owner;
-    bytes_t amount;
-} tx_redelegation_t;
-
-typedef struct {} tx_custom_t;
-
-typedef struct {
-    bytes_t pubkey;
-} tx_reveal_pubkey_t;
-
-typedef struct {
-    bytes_t validator;
-    uint8_t has_source;
-    bytes_t source;
-} tx_withdraw_t;
-
-typedef struct {
-    bytes_t validator;
-} tx_unjail_validator_t;
-
-typedef tx_unjail_validator_t tx_activate_validator_t;
-
-typedef struct {
-    bytes_t validator;
-    bytes_t new_rate;
-} tx_commission_change_t;
-
-typedef struct {
-    bytes_t address;
-    bytes_t consensus_key;
-    bytes_t eth_cold_key;
-    bytes_t eth_hot_key;
-    bytes_t protocol_key;
-    bytes_t commission_rate;
-    bytes_t max_commission_rate_change;
-    bytes_t email;
-    bytes_t description;
-    bytes_t website;
-    bytes_t discord_handle;
-    bytes_t avatar;
-} tx_become_validator_t;
-
-typedef struct {
-    bytes_t address;
-    uint32_t number_of_pubkeys;
-    bytes_t pubkeys;
-    uint8_t has_threshold;
-    uint8_t threshold;
-    uint8_t has_vp_code;
-    bytes_t vp_type_sechash;
-    bytes_t vp_type_hash;
-    uint8_t vp_type_secidx;
-    const char* vp_type_text;
-} tx_update_vp_t;
-
-typedef struct {
   uint8_t f0[20];
 } IbcTokenHash;
 
@@ -348,10 +191,167 @@ typedef struct {
 } AddressAlt;
 
 typedef struct {
+    uint8_t *ptr;
+    uint32_t len;
+} mut_bytes_t;
+
+typedef struct {
+    AddressAlt address;
+    bytes_t amount;
+} pgf_internal_t;
+
+typedef struct {
+    bytes_t target;
+    bytes_t amount;
+    bytes_t portId;
+    bytes_t channelId;
+} pgf_ibc_t;
+typedef struct {
+    pgf_action_e action;
+    pgf_continuous_type_e add_rem;
+    pgf_target_type_e targetType;
+    union {
+        pgf_internal_t internal;
+        pgf_ibc_t ibc;
+    };
+    uint16_t length;
+} pgf_payment_action_t;
+
+typedef struct {
+    uint64_t proposal_id;
+    bytes_t content_hash;
+    bytes_t content_sechash;
+    AddressAlt author;
+    uint64_t voting_start_epoch;
+    uint64_t voting_end_epoch;
+    uint64_t grace_epoch;
+    uint8_t proposal_type;
+    union {
+        struct {
+            uint8_t has_proposal_code;
+            bytes_t proposal_code_sechash;
+            bytes_t proposal_code_hash;
+        };
+        struct {
+            uint32_t pgf_steward_actions_num;
+            bytes_t pgf_steward_actions;
+        };
+        struct {
+            uint32_t pgf_payment_actions_num;
+            uint32_t pgf_payment_ibc_num;
+            bytes_t pgf_payment_actions;
+        };
+    };
+
+    uint8_t content_secidx;
+    uint8_t proposal_code_secidx;
+} tx_init_proposal_t;
+
+
+typedef struct {
+    uint64_t millis;
+    uint32_t nanos;
+} timestamp_t;
+
+typedef struct {
+    bytes_t council_address;
+    bytes_t amount;
+} council_t;
+
+typedef struct {
+    uint64_t proposal_id;
+    proposal_vote_e proposal_vote;
+    yay_vote_type_e vote_type;
+    uint32_t number_of_councils;
+    bytes_t councils;
+    bytes_t eth_bridge_signature;
+    // proposal author address
+    AddressAlt voter;
+    // Delegator addresses
+    uint32_t number_of_delegations;
+    bytes_t delegations;
+} tx_vote_proposal_t;
+
+typedef struct {
+    uint32_t number_of_pubkeys;
+    bytes_t pubkeys;
+    uint8_t threshold;
+    bytes_t vp_type_sechash;
+    bytes_t vp_type_hash;
+    uint8_t vp_type_secidx;
+    const char* vp_type_text;
+} tx_init_account_t;
+
+typedef struct {
+    AddressAlt validator;
+    bytes_t amount;
+    uint8_t has_source;
+    AddressAlt source;
+} tx_bond_t;
+
+typedef struct {
+    AddressAlt src_validator;
+    AddressAlt dest_validator;
+    AddressAlt owner;
+    bytes_t amount;
+} tx_redelegation_t;
+
+typedef struct {} tx_custom_t;
+
+typedef struct {
+    bytes_t pubkey;
+} tx_reveal_pubkey_t;
+
+typedef struct {
+    AddressAlt validator;
+    uint8_t has_source;
+    AddressAlt source;
+} tx_withdraw_t;
+
+typedef struct {
+    AddressAlt validator;
+} tx_unjail_validator_t;
+
+typedef tx_unjail_validator_t tx_activate_validator_t;
+
+typedef struct {
+    AddressAlt validator;
+    bytes_t new_rate;
+} tx_commission_change_t;
+
+typedef struct {
+    AddressAlt address;
+    bytes_t consensus_key;
+    bytes_t eth_cold_key;
+    bytes_t eth_hot_key;
+    bytes_t protocol_key;
+    bytes_t commission_rate;
+    bytes_t max_commission_rate_change;
+    bytes_t email;
+    bytes_t description;
+    bytes_t website;
+    bytes_t discord_handle;
+    bytes_t avatar;
+} tx_become_validator_t;
+
+typedef struct {
+    AddressAlt address;
+    uint32_t number_of_pubkeys;
+    bytes_t pubkeys;
+    uint8_t has_threshold;
+    uint8_t threshold;
+    uint8_t has_vp_code;
+    bytes_t vp_type_sechash;
+    bytes_t vp_type_hash;
+    uint8_t vp_type_secidx;
+    const char* vp_type_text;
+} tx_update_vp_t;
+
+typedef struct {
     AddressAlt source_address;
     AddressAlt target_address;
     // Transferred token address
-    bytes_t token;
+    AddressAlt token;
     uint8_t has_sub_prefix;
     bytes_t sub_prefix;
     bytes_t amount;
@@ -377,16 +377,16 @@ typedef struct {
 } tx_ibc_t;
 
 typedef struct {
-    bytes_t steward;
+    AddressAlt steward;
 } tx_resign_steward_t;
 
 typedef struct {
-    bytes_t validator;
+    AddressAlt validator;
     bytes_t consensus_key;
 } tx_consensus_key_change_t;
 
 typedef struct {
-    bytes_t steward;
+    AddressAlt steward;
     uint32_t commissionLen;
     bytes_t commission;
 } tx_update_steward_commission_t;
@@ -395,16 +395,16 @@ typedef struct {
     uint8_t kind;
     bytes_t asset;
     bytes_t recipient;
-    bytes_t sender;
+    AddressAlt sender;
     bytes_t amount;
 
-    bytes_t gasToken;
+    AddressAlt gasToken;
     bytes_t gasAmount;
-    bytes_t gasPayer;
+    AddressAlt gasPayer;
 } tx_bridge_pool_transfer_t;
 
   typedef struct {
-    bytes_t validator;
+    AddressAlt validator;
     bytes_t email;
     bytes_t description;
     bytes_t website;
@@ -415,7 +415,7 @@ typedef struct {
   } tx_metadata_change_t;
 
 typedef struct {
-    bytes_t address;
+    AddressAlt address;
     bytes_t amount;
     uint8_t denom;
     const char *symbol;

--- a/app/src/parser_types.h
+++ b/app/src/parser_types.h
@@ -256,8 +256,100 @@ typedef struct {
 } tx_update_vp_t;
 
 typedef struct {
-    bytes_t source_address;
-    bytes_t target_address;
+  uint8_t f0[20];
+} IbcTokenHash;
+
+typedef struct {
+  uint8_t f0[20];
+} EthAddress;
+
+typedef struct {
+  uint8_t f0[20];
+} PublicKeyHash;
+
+typedef struct {
+  uint8_t hash[20];
+} EstablishedAddress;
+
+typedef struct {
+  EstablishedAddress f0;
+} AddressEstablished;
+
+typedef struct {
+  PublicKeyHash f0;
+} ImplicitAddress;
+
+typedef struct {
+  ImplicitAddress f0;
+} AddressImplicit;
+
+typedef struct {
+  EthAddress f0;
+} InternalAddressErc20;
+
+typedef struct {} InternalAddressEthBridge;
+
+typedef struct {} InternalAddressEthBridgePool;
+
+typedef struct {} InternalAddressGovernance;
+
+typedef struct {} InternalAddressIbc;
+
+typedef struct {
+  IbcTokenHash f0;
+} InternalAddressIbcToken;
+
+typedef struct {} InternalAddressMasp;
+
+typedef struct {} InternalAddressMultitoken;
+
+typedef struct {
+  EthAddress f0;
+} InternalAddressNut;
+
+typedef struct {} InternalAddressParameters;
+
+typedef struct {} InternalAddressPgf;
+
+typedef struct {} InternalAddressPoS;
+
+typedef struct {} InternalAddressPosSlashPool;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  InternalAddressPoS PoS;
+  InternalAddressPosSlashPool PosSlashPool;
+  InternalAddressParameters Parameters;
+  InternalAddressIbc Ibc;
+  InternalAddressIbcToken IbcToken;
+  InternalAddressGovernance Governance;
+  InternalAddressEthBridge EthBridge;
+  InternalAddressEthBridgePool EthBridgePool;
+  InternalAddressErc20 Erc20;
+  InternalAddressNut Nut;
+  InternalAddressMultitoken Multitoken;
+  InternalAddressPgf Pgf;
+  InternalAddressMasp Masp;
+  };
+} InternalAddress;
+
+typedef struct {
+  InternalAddress f0;
+} AddressInternal;
+
+typedef struct {
+  uint8_t tag;
+  union {
+  AddressEstablished Established;
+  AddressImplicit Implicit;
+  AddressInternal Internal;
+  };
+} AddressAlt;
+
+typedef struct {
+    AddressAlt source_address;
+    AddressAlt target_address;
     // Transferred token address
     bytes_t token;
     uint8_t has_sub_prefix;

--- a/app/src/txn_delegation.c
+++ b/app/src/txn_delegation.c
@@ -26,8 +26,7 @@ parser_error_t readBondUnbond(const bytes_t *data, parser_tx_t *v) {
     parser_context_t ctx = {.buffer = data->ptr, .bufferLen = data->len, .offset = 0, .tx_obj = NULL};
 
     // Validator
-    v->bond.validator.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &v->bond.validator.ptr, v->bond.validator.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &v->bond.validator))
 
     // Amount
     v->bond.amount.len = 32;
@@ -36,8 +35,7 @@ parser_error_t readBondUnbond(const bytes_t *data, parser_tx_t *v) {
     // Source
     readByte(&ctx, &v->bond.has_source);
     if (v->bond.has_source) {
-        v->bond.source.len = ADDRESS_LEN_BYTES;
-        CHECK_ERROR(readBytes(&ctx, &v->bond.source.ptr, v->bond.source.len))
+        CHECK_ERROR(readAddressAlt(&ctx, &v->bond.source))
         v->bond.has_source = 1;
     }
 
@@ -52,16 +50,13 @@ parser_error_t readRedelegate(const bytes_t *data, tx_redelegation_t *redelegati
     parser_context_t ctx = {.buffer = data->ptr, .bufferLen = data->len, .offset = 0, .tx_obj = NULL};
 
     // Source validator
-    redelegation->src_validator.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &redelegation->src_validator.ptr, redelegation->src_validator.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &redelegation->src_validator))
 
     // Destination validator
-    redelegation->dest_validator.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &redelegation->dest_validator.ptr, redelegation->dest_validator.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &redelegation->dest_validator))
 
     // Owner
-    redelegation->owner.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &redelegation->owner.ptr, redelegation->owner.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &redelegation->owner))
 
     // Amount
     redelegation->amount.len = 32;
@@ -100,15 +95,15 @@ parser_error_t printRedelegate(const parser_context_t *ctx,
             break;
         case 1:
             snprintf(outKey, outKeyLen, "Source Validator");
-            CHECK_ERROR(printAddress(redelegation->src_validator, outVal, outValLen, pageIdx, pageCount))
+            CHECK_ERROR(printAddressAlt(&redelegation->src_validator, outVal, outValLen, pageIdx, pageCount))
             break;
         case 2:
             snprintf(outKey, outKeyLen, "Destination Validator");
-            CHECK_ERROR(printAddress(redelegation->dest_validator, outVal, outValLen, pageIdx, pageCount))
+            CHECK_ERROR(printAddressAlt(&redelegation->dest_validator, outVal, outValLen, pageIdx, pageCount))
             break;
         case 3:
             snprintf(outKey, outKeyLen, "Owner");
-            CHECK_ERROR(printAddress(redelegation->owner, outVal, outValLen, pageIdx, pageCount))
+            CHECK_ERROR(printAddressAlt(&redelegation->owner, outVal, outValLen, pageIdx, pageCount))
             break;
         case 4:
             snprintf(outKey, outKeyLen, "Amount");

--- a/app/src/txn_validator.c
+++ b/app/src/txn_validator.c
@@ -23,8 +23,7 @@ parser_error_t readBecomeValidator(const bytes_t *data, const section_t *extra_d
     }
     parser_context_t ctx = {.buffer = data->ptr, .bufferLen = data->len, .offset = 0, .tx_obj = NULL};
 
-    v->becomeValidator.address.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &v->becomeValidator.address.ptr, v->becomeValidator.address.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &v->becomeValidator.address))
 
     CHECK_ERROR(readPubkey(&ctx, &v->becomeValidator.consensus_key))
 
@@ -123,11 +122,7 @@ parser_error_t readUnjailValidator(const bytes_t *data, parser_tx_t *v) {
     parser_context_t ctx = {.buffer = data->ptr, .bufferLen = data->len, .offset = 0, .tx_obj = NULL};
 
     // Address
-    if (ctx.bufferLen != ADDRESS_LEN_BYTES) {
-        return parser_unexpected_value;
-    }
-    v->revealPubkey.pubkey.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &v->unjailValidator.validator.ptr, v->unjailValidator.validator.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &v->unjailValidator.validator))
 
     if (ctx.offset != ctx.bufferLen) {
         return parser_unexpected_characters;
@@ -143,12 +138,7 @@ parser_error_t readActivateValidator(const bytes_t *data, tx_activate_validator_
     parser_context_t ctx = {.buffer = data->ptr, .bufferLen = data->len, .offset = 0, .tx_obj = NULL};
 
     // Address
-    if (ctx.bufferLen != ADDRESS_LEN_BYTES) {
-        return parser_unexpected_value;
-    }
-
-    txObject->validator.len = ADDRESS_LEN_BYTES;
-    CHECK_ERROR(readBytes(&ctx, &txObject->validator.ptr, txObject->validator.len))
+    CHECK_ERROR(readAddressAlt(&ctx, &txObject->validator))
 
     if (ctx.offset != ctx.bufferLen) {
         return parser_unexpected_characters;


### PR DESCRIPTION
Implemented the parsing of MASP `Transaction`s and `Builder`s. Some notes:
* The code was generated by running a C parser generator on the following Borsh schema: [masp_borsh_schema.txt](https://github.com/Zondax/ledger-namada/files/14326797/masp_borsh_schema.txt) . The format's documentation can be found [here](https://docs.rs/borsh/latest/borsh/schema/index.html).
* The generator calls `mem_alloc` to support parsing variable length arrays, but this dependency should be easily removable if upper bounds can be established on the vectors occurring in the serializations.
* More types of Namada addresses can now be parsed including internal Ethereum addresses. Full parsing of addresses is required to be able to decode `AssetType`s.
* The test vectors have been temporarily filtered to include only MASP transactions since that is the focus of this branch. However it should still support all test vectors from Ledger app v0.0.18.
