### PR TITLE
Fixed update account transaction signing

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -284,9 +284,11 @@ static zxerr_t crypto_addTxnHashes(const parser_tx_t *txObj, concatenated_hashes
             break;
 
         case UpdateVP:
-            MEMCPY(hashes->hashes.ptr + hashes->hashesLen * HASH_LEN, txObj->updateVp.vp_type_sechash.ptr, HASH_LEN);
-            hashes->indices.ptr[hashes->hashesLen] = txObj->updateVp.vp_type_secidx;
-            hashes->hashesLen++;
+            if (txObj->updateVp.has_vp_code) {
+                MEMCPY(hashes->hashes.ptr + hashes->hashesLen * HASH_LEN, txObj->updateVp.vp_type_sechash.ptr, HASH_LEN);
+                hashes->indices.ptr[hashes->hashesLen] = txObj->updateVp.vp_type_secidx;
+                hashes->hashesLen++;
+            }
             break;
 
         case InitProposal:


### PR DESCRIPTION
While the printing works, attempting to sign an update account transaction that contains no VP code hash causes the hardware wallet to crash. The cause of this issue seems to be that the signing code does not first check whether the VP code hash is present, and therefore attempts to read an uninitialized pointer. This PR attempts to fix this.