### PR TITLE
Murisi/fix signature indexing

### DIFF
--- a/app/src/nvdata.c
+++ b/app/src/nvdata.c
@@ -120,29 +120,29 @@ uint8_t transaction_get_n_converts() {
 }
 
 bool spend_signatures_more_extract() {
-  return transaction_header.spends_sign_index > 0;
+  return transaction_header.spends_sign_index < transaction_header.spends_sign_len;
 }
 
 zxerr_t spend_signatures_append(uint8_t *signature) {
-  if (transaction_header.spends_sign_index >=
+  if (transaction_header.spends_sign_len >=
       transaction_header.spendlist_len) {
     return zxerr_unknown;
   }
 
   MEMCPY_NV((void *)&N_transactioninfo
-                .spend_signatures[transaction_header.spends_sign_index],
+                .spend_signatures[transaction_header.spends_sign_len],
             signature, SIGNATURE_SIZE);
-  transaction_header.spends_sign_index++;
+  transaction_header.spends_sign_len++;
   return zxerr_ok;
 }
 
 zxerr_t get_next_spend_signature(uint8_t *result) {
-  const uint8_t index = transaction_header.spendlist_len - transaction_header.spends_sign_index;
-  if (index >= transaction_header.spendlist_len) {
+  const uint8_t index = transaction_header.spends_sign_index;
+  if (index >= transaction_header.spends_sign_len) {
     return zxerr_unknown;
   }
   MEMCPY(result, (void *)&N_transactioninfo.spend_signatures[index], SIGNATURE_SIZE);
-  transaction_header.spends_sign_index--;
+  transaction_header.spends_sign_index++;
   if (!spend_signatures_more_extract()) {
     transaction_reset();
   }
@@ -152,10 +152,11 @@ zxerr_t get_next_spend_signature(uint8_t *result) {
 void zeroize_signatures() {
   uint8_t sig[SIGNATURE_SIZE] = {0};
 
-  transaction_header.spends_sign_index = 0;
+  transaction_header.spends_sign_len = 0;
   for (int i = 0; i < SPEND_LIST_SIZE; i++) {
     spend_signatures_append(sig);
   }
+  transaction_header.spends_sign_len = 0;
   transaction_header.spends_sign_index = 0;
 }
 

--- a/app/src/nvdata.h
+++ b/app/src/nvdata.h
@@ -53,6 +53,7 @@ typedef struct {
   uint8_t spendlist_len;
   uint8_t outputlist_len;
   uint8_t convertlist_len;
+  uint8_t spends_sign_len;
   uint8_t spends_sign_index;
 } transaction_header_t;
 


### PR DESCRIPTION
An attempt to close #70 . Fixes the issue where incorrect spend authorization signatures are returned when the number of spend randomness parameters exceeds the number of spend descriptions. This fix essentially uses a new separate variable (instead of index difference arithmetic) to track which spend authorization signature we are returning next.