### PR TITLE
Ensure that the seeking of convert descriptions starts from zero.

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -855,6 +855,7 @@ parser_error_t checkConverts(const parser_tx_t *txObj, parser_context_t *builder
         }
 
         builder_converts_ctx->offset = 0;
+        tx_converts_ctx->offset = 0;
     }
     return parser_ok;
 }


### PR DESCRIPTION
An attempt to address https://github.com/Zondax/ledger-namada/issues/76 . Essentially the code is adjusted to ensure that the offsets of convert descriptions are always computed with respect to the beginning of the convert description buffer.