### PR TITLE
Murisi/allow separate sessions

### DIFF
--- a/app/src/crypto.c
+++ b/app/src/crypto.c
@@ -826,7 +826,7 @@ parser_error_t checkConverts(const parser_tx_t *txObj, parser_context_t *builder
     }
 
     if (txObj->transaction.sections.maspBuilder.metadata.n_converts_indices != txObj->transaction.sections.maspTx.data.sapling_bundle.n_shielded_converts) {
-        return parser_invalid_number_of_outputs;
+        return parser_invalid_number_of_converts;
     }
 
     for (uint32_t i = 0; i < txObj->transaction.sections.maspBuilder.builder.sapling_builder.n_converts; i++) {

--- a/app/src/parser_impl_masp.c
+++ b/app/src/parser_impl_masp.c
@@ -28,6 +28,8 @@
     #include "cx_blake2b.h"
 #endif
 
+#define OFFSET_INS                      1  //< Instruction offset
+
 static parser_error_t readSaplingBundle(parser_context_t *ctx, masp_sapling_bundle_t *bundle) {
     if (ctx == NULL || bundle == NULL) {
         return parser_unexpected_error;
@@ -170,9 +172,11 @@ static parser_error_t readSpendDescriptionInfo(parser_context_t *ctx, masp_sapli
 
     CHECK_ERROR(readUint32(ctx, &builder->n_spends))
 #if defined(LEDGER_SPECIFIC) && !defined(APP_TESTING)
-    uint32_t rnd_spends = (uint32_t)transaction_get_n_spends();
-    if (rnd_spends < builder->n_spends) {
-        return parser_invalid_number_of_spends;
+    if (G_io_apdu_buffer[OFFSET_INS] == INS_SIGN_MASP_SPENDS) {
+        uint32_t rnd_spends = (uint32_t)transaction_get_n_spends();
+        if (rnd_spends < builder->n_spends) {
+            return parser_invalid_number_of_spends;
+        }
     }
 #endif
 
@@ -288,9 +292,11 @@ static parser_error_t readConvertDescriptionInfo(parser_context_t *ctx, masp_sap
 
     CHECK_ERROR(readUint32(ctx, &builder->n_converts))
 #if defined(LEDGER_SPECIFIC) && !defined(APP_TESTING)
-    uint32_t rnd_converts = (uint32_t)transaction_get_n_converts();
-    if (rnd_converts < builder->n_converts) {
-        return parser_invalid_number_of_converts;
+    if (G_io_apdu_buffer[OFFSET_INS] == INS_SIGN_MASP_SPENDS) {
+        uint32_t rnd_converts = (uint32_t)transaction_get_n_converts();
+        if (rnd_converts < builder->n_converts) {
+            return parser_invalid_number_of_converts;
+        }
     }
 #endif
 
@@ -332,6 +338,14 @@ static parser_error_t readSaplingOutputDescriptionInfo(parser_context_t *ctx, ma
     }
 
     CHECK_ERROR(readUint32(ctx, &builder->n_outputs))
+#if defined(LEDGER_SPECIFIC) && !defined(APP_TESTING)
+    if (G_io_apdu_buffer[OFFSET_INS] == INS_SIGN_MASP_SPENDS) {
+        uint32_t rnd_outputs = (uint32_t)transaction_get_n_outputs();
+        if (rnd_outputs < builder->n_outputs) {
+            return parser_invalid_number_of_outputs;
+        }
+    }
+#endif
 
     // Get start pointer and offset to later calculate the size of the outputs
     builder->outputs.ptr = ctx->buffer + ctx->offset;


### PR DESCRIPTION
An attempt to address https://github.com/Zondax/ledger-namada/issues/78 . This PR makes the Ledger app only check that the number of generated random parameters are correct in the case where it also has to produce the spend authorization signatures (using the parameters).